### PR TITLE
Centralize mock data in single file

### DIFF
--- a/src/core/services/api/chatApiClient.js
+++ b/src/core/services/api/chatApiClient.js
@@ -1,4 +1,10 @@
 import ApiClient from './ApiClient'
+import {
+  MOCK_CHAT_ROOMS_RESPONSE,
+  MOCK_CHAT_MESSAGES_RESPONSE,
+  createMockMessage,
+  createMockRoom,
+} from '@/data/mockChat'
 
 /**
  * Chat API Client
@@ -22,57 +28,9 @@ class ChatApiClient extends ApiClient {
    * @returns {Promise<ChatRoomListResponse>}
    */
   async getRooms() {
-    const mockResponse = () => ({
-      rooms: [
-        {
-          roomId: 'room_001',
-          counselor: {
-            id: 'doctor_001',
-            name: '김의사',
-            type: 'doctor', // 'doctor' | 'ai_bot'
-            profileImage: 'https://via.placeholder.com/100',
-            hospitalName: '서울대병원',
-            specialty: '내과',
-            isOnline: true,
-          },
-          lastMessage: {
-            messageId: 'msg_123',
-            content: '혈압약은 저녁 식사 후에 복용하시면 됩니다.',
-            senderId: 'doctor_001',
-            timestamp: new Date(Date.now() - 1000 * 60 * 30).toISOString(), // 30분 전
-            isRead: true,
-          },
-          unreadCount: 0,
-          createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(), // 3일 전
-          updatedAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-        },
-        {
-          roomId: 'room_002',
-          counselor: {
-            id: 'ai_bot_001',
-            name: 'AMA AI 챗봇',
-            type: 'ai_bot',
-            profileImage: 'https://via.placeholder.com/100',
-            hospitalName: null,
-            specialty: '건강 상담',
-            isOnline: true,
-          },
-          lastMessage: {
-            messageId: 'msg_456',
-            content: '안녕하세요! 약물 복용에 대해 무엇이든 물어보세요.',
-            senderId: 'ai_bot_001',
-            timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(), // 2시간 전
-            isRead: false,
-          },
-          unreadCount: 2,
-          createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString(), // 7일 전
-          updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
-        },
-      ],
-      totalCount: 2,
+    return this.get('/rooms', {}, {
+      mockResponse: () => MOCK_CHAT_ROOMS_RESPONSE,
     })
-
-    return this.get('/rooms', {}, { mockResponse })
   }
 
   /**
@@ -84,60 +42,12 @@ class ChatApiClient extends ApiClient {
   async getMessages(roomId, options = {}) {
     const { limit = 50, before } = options
 
-    const mockResponse = () => ({
-      roomId,
-      messages: [
-        {
-          messageId: 'msg_001',
-          roomId,
-          senderId: 'user_12345',
-          senderType: 'user', // 'user' | 'pharmacist'
-          content: '안녕하세요, 복용 중인 약에 대해 궁금한 게 있어요.',
-          timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(), // 1일 전
-          isRead: true,
-        },
-        {
-          messageId: 'msg_002',
-          roomId,
-          senderId: 'doctor_001',
-          senderType: 'counselor',
-          content: '네, 말씀하세요. 어떤 부분이 궁금하신가요?',
-          timestamp: new Date(Date.now() - 1000 * 60 * 60 * 23).toISOString(),
-          isRead: true,
-        },
-        {
-          messageId: 'msg_003',
-          roomId,
-          senderId: 'user_12345',
-          senderType: 'user',
-          content: '혈압약을 아침에 먹어야 하나요, 저녁에 먹어야 하나요?',
-          timestamp: new Date(Date.now() - 1000 * 60 * 60 * 23 + 1000 * 60 * 5).toISOString(),
-          isRead: true,
-        },
-        {
-          messageId: 'msg_004',
-          roomId,
-          senderId: 'doctor_001',
-          senderType: 'counselor',
-          content: '혈압약은 보통 저녁 식사 후에 복용하는 것을 권장합니다. 잠들기 전에 혈압이 높아지는 것을 방지할 수 있기 때문입니다.',
-          timestamp: new Date(Date.now() - 1000 * 60 * 60 * 22).toISOString(),
-          isRead: true,
-        },
-        {
-          messageId: 'msg_005',
-          roomId,
-          senderId: 'user_12345',
-          senderType: 'user',
-          content: '감사합니다! 도움이 많이 되었어요.',
-          timestamp: new Date(Date.now() - 1000 * 60 * 60 * 22 + 1000 * 60 * 2).toISOString(),
-          isRead: true,
-        },
-      ],
-      hasMore: false,
-      nextCursor: null,
+    return this.get(`/rooms/${roomId}/messages`, { params: { limit, before } }, {
+      mockResponse: () => ({
+        roomId,
+        ...MOCK_CHAT_MESSAGES_RESPONSE,
+      }),
     })
-
-    return this.get(`/rooms/${roomId}/messages`, { params: { limit, before } }, { mockResponse })
   }
 
   /**
@@ -147,17 +57,9 @@ class ChatApiClient extends ApiClient {
    * @returns {Promise<ChatMessage>}
    */
   async sendMessage(roomId, content) {
-    const mockResponse = () => ({
-      messageId: `msg_${Date.now()}`,
-      roomId,
-      senderId: 'user_12345',
-      senderType: 'user',
-      content,
-      timestamp: new Date().toISOString(),
-      isRead: false,
+    return this.post(`/rooms/${roomId}/messages`, { content }, {}, {
+      mockResponse: () => createMockMessage(roomId, content),
     })
-
-    return this.post(`/rooms/${roomId}/messages`, { content }, {}, { mockResponse })
   }
 
   /**
@@ -167,24 +69,9 @@ class ChatApiClient extends ApiClient {
    * @returns {Promise<ChatRoom>}
    */
   async createRoom(counselorId, type = 'doctor') {
-    const mockResponse = () => ({
-      roomId: `room_${Date.now()}`,
-      counselor: {
-        id: counselorId,
-        name: type === 'ai_bot' ? 'AMA AI 챗봇' : '새 의사',
-        type,
-        profileImage: 'https://via.placeholder.com/100',
-        hospitalName: type === 'ai_bot' ? null : '새 병원',
-        specialty: type === 'ai_bot' ? '건강 상담' : '일반의',
-        isOnline: true,
-      },
-      lastMessage: null,
-      unreadCount: 0,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+    return this.post('/rooms', { counselorId, type }, {}, {
+      mockResponse: () => createMockRoom(counselorId, type),
     })
-
-    return this.post('/rooms', { counselorId, type }, {}, { mockResponse })
   }
 
   /**

--- a/src/core/services/api/ocrApiClient.js
+++ b/src/core/services/api/ocrApiClient.js
@@ -1,4 +1,5 @@
 import ApiClient from './ApiClient'
+import { createMockOcrResponse } from '@/data/mockOcr'
 
 class OcrApiClient extends ApiClient {
   constructor() {
@@ -9,20 +10,11 @@ class OcrApiClient extends ApiClient {
   }
 
   recognize(formData) {
-    const mockResponse = () => ({
-      text: `약품명: ${formData?.get('file')?.name || '신규 처방약'}
-복용량: 1정
-복용 일정: 하루 1회 (저녁 식후)
-주의사항: 자몽 주스와 동시 복용 금지`,
-      insights: [
-        '인식한 내용을 약 관리 CRUD에 바로 등록하세요.',
-        '식단 기록시 자몽, 비타민 K 음식과 충돌 여부를 확인하세요.',
-      ],
-    })
-
     return this.post('/recognize', formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
-    }, { mockResponse })
+    }, {
+      mockResponse: () => createMockOcrResponse(formData?.get('file')?.name),
+    })
   }
 }
 

--- a/src/data/mockChat.js
+++ b/src/data/mockChat.js
@@ -1,3 +1,10 @@
+/**
+ * Chat Mock 데이터
+ * @file mockChat.js
+ * @description 채팅 API용 Mock 데이터
+ */
+
+// 채팅방 목록 응답
 export const MOCK_CHAT_ROOMS_RESPONSE = {
   rooms: [
     {
@@ -5,7 +12,7 @@ export const MOCK_CHAT_ROOMS_RESPONSE = {
       counselor: {
         id: 'doctor_001',
         name: '김의사',
-        type: 'doctor', // 'doctor' | 'ai_bot'
+        type: 'doctor',
         profileImage: 'https://via.placeholder.com/100',
         hospitalName: '서울대병원',
         specialty: '내과',
@@ -15,11 +22,11 @@ export const MOCK_CHAT_ROOMS_RESPONSE = {
         messageId: 'msg_123',
         content: '혈압약은 저녁 식사 후에 복용하시면 됩니다.',
         senderId: 'doctor_001',
-        timestamp: new Date(Date.now() - 1000 * 60 * 30).toISOString(), // 30분 전
+        timestamp: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
         isRead: true,
       },
       unreadCount: 0,
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(), // 3일 전
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(),
       updatedAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
     },
     {
@@ -37,25 +44,26 @@ export const MOCK_CHAT_ROOMS_RESPONSE = {
         messageId: 'msg_456',
         content: '안녕하세요! 약물 복용에 대해 무엇이든 물어보세요.',
         senderId: 'ai_bot_001',
-        timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(), // 2시간 전
+        timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
         isRead: false,
       },
       unreadCount: 2,
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString(), // 7일 전
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString(),
       updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
     },
   ],
   totalCount: 2,
-};
+}
 
+// 채팅 메시지 응답
 export const MOCK_CHAT_MESSAGES_RESPONSE = {
   messages: [
     {
       messageId: 'msg_001',
       senderId: 'user_12345',
-      senderType: 'user', // 'user' | 'pharmacist'
+      senderType: 'user',
       content: '안녕하세요, 복용 중인 약에 대해 궁금한 게 있어요.',
-      timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(), // 1일 전
+      timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
       isRead: true,
     },
     {
@@ -66,7 +74,67 @@ export const MOCK_CHAT_MESSAGES_RESPONSE = {
       timestamp: new Date(Date.now() - 1000 * 60 * 60 * 23).toISOString(),
       isRead: true,
     },
+    {
+      messageId: 'msg_003',
+      senderId: 'user_12345',
+      senderType: 'user',
+      content: '혈압약을 아침에 먹어야 하나요, 저녁에 먹어야 하나요?',
+      timestamp: new Date(Date.now() - 1000 * 60 * 60 * 23 + 1000 * 60 * 5).toISOString(),
+      isRead: true,
+    },
+    {
+      messageId: 'msg_004',
+      senderId: 'doctor_001',
+      senderType: 'counselor',
+      content: '혈압약은 보통 저녁 식사 후에 복용하는 것을 권장합니다. 잠들기 전에 혈압이 높아지는 것을 방지할 수 있기 때문입니다.',
+      timestamp: new Date(Date.now() - 1000 * 60 * 60 * 22).toISOString(),
+      isRead: true,
+    },
+    {
+      messageId: 'msg_005',
+      senderId: 'user_12345',
+      senderType: 'user',
+      content: '감사합니다! 도움이 많이 되었어요.',
+      timestamp: new Date(Date.now() - 1000 * 60 * 60 * 22 + 1000 * 60 * 2).toISOString(),
+      isRead: true,
+    },
   ],
   hasMore: false,
   nextCursor: null,
-};
+}
+
+// 채팅 메시지 생성 헬퍼
+export const createMockMessage = (roomId, content) => ({
+  messageId: `msg_${Date.now()}`,
+  roomId,
+  senderId: 'user_12345',
+  senderType: 'user',
+  content,
+  timestamp: new Date().toISOString(),
+  isRead: false,
+})
+
+// 새 채팅방 생성 헬퍼
+export const createMockRoom = (counselorId, type = 'doctor') => ({
+  roomId: `room_${Date.now()}`,
+  counselor: {
+    id: counselorId,
+    name: type === 'ai_bot' ? 'AMA AI 챗봇' : '새 의사',
+    type,
+    profileImage: 'https://via.placeholder.com/100',
+    hospitalName: type === 'ai_bot' ? null : '새 병원',
+    specialty: type === 'ai_bot' ? '건강 상담' : '일반의',
+    isOnline: true,
+  },
+  lastMessage: null,
+  unreadCount: 0,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+})
+
+export default {
+  MOCK_CHAT_ROOMS_RESPONSE,
+  MOCK_CHAT_MESSAGES_RESPONSE,
+  createMockMessage,
+  createMockRoom,
+}

--- a/src/data/mockOcr.js
+++ b/src/data/mockOcr.js
@@ -1,3 +1,9 @@
+/**
+ * OCR Mock 데이터
+ * @file mockOcr.js
+ * @description 처방전 OCR 인식 결과 Mock 데이터
+ */
+
 export const MOCK_OCR_RESPONSE = {
   text: `약품명: 신규 처방약
 복용량: 1정
@@ -8,3 +14,17 @@ export const MOCK_OCR_RESPONSE = {
     '식단 기록시 자몽, 비타민 K 음식과 충돌 여부를 확인하세요.',
   ],
 }
+
+// OCR 응답 생성 헬퍼 (파일 이름 기반)
+export const createMockOcrResponse = (fileName = '신규 처방약') => ({
+  text: `약품명: ${fileName}
+복용량: 1정
+복용 일정: 하루 1회 (저녁 식후)
+주의사항: 자몽 주스와 동시 복용 금지`,
+  insights: [
+    '인식한 내용을 약 관리 CRUD에 바로 등록하세요.',
+    '식단 기록시 자몽, 비타민 K 음식과 충돌 여부를 확인하세요.',
+  ],
+})
+
+export default { MOCK_OCR_RESPONSE, createMockOcrResponse }

--- a/src/data/mockReports.js
+++ b/src/data/mockReports.js
@@ -4,6 +4,29 @@
  * @description 복약 순응도 리포트 및 주간 통계용 Mock 데이터
  */
 
+// 복약 순응도 페이지용 요약 데이터
+export const MOCK_ADHERENCE_PAGE_DATA = {
+  overall: 87,
+  thisWeek: 92,
+  lastWeek: 85,
+  thisMonth: 87,
+  streak: 14,
+  totalDays: 90,
+  completedDays: 78,
+  missedDays: 12,
+}
+
+// 최근 복약 히스토리
+export const MOCK_RECENT_HISTORY = [
+  { date: '2025-01-18', status: 'completed', count: 3, total: 3 },
+  { date: '2025-01-17', status: 'completed', count: 3, total: 3 },
+  { date: '2025-01-16', status: 'partial', count: 2, total: 3 },
+  { date: '2025-01-15', status: 'completed', count: 3, total: 3 },
+  { date: '2025-01-14', status: 'missed', count: 1, total: 3 },
+  { date: '2025-01-13', status: 'completed', count: 3, total: 3 },
+  { date: '2025-01-12', status: 'completed', count: 3, total: 3 },
+]
+
 export const MOCK_ADHERENCE_REPORT = {
   id: 'report-adherence-1',
   period: '2025-11-12',

--- a/src/data/mockUiConstants.js
+++ b/src/data/mockUiConstants.js
@@ -1,0 +1,131 @@
+/**
+ * UI 상수 Mock 데이터
+ * @file mockUiConstants.js
+ * @description 대시보드, 설정 등의 UI 상수 데이터
+ */
+
+import { ROUTE_PATHS } from '@config/routes.config'
+
+// 시니어 대시보드 빠른 액션
+export const SENIOR_QUICK_ACTIONS = [
+  { icon: '💊', label: '약 등록', path: ROUTE_PATHS.medicationAdd },
+  { icon: '🔍', label: '검색', path: ROUTE_PATHS.search },
+  { icon: '🍽️', label: '식단 경고', path: ROUTE_PATHS.dietWarning },
+  { icon: '📊', label: '복용 리포트', path: ROUTE_PATHS.adherenceReport },
+]
+
+// 시니어 대시보드 FAB 액션
+export const SENIOR_FAB_ACTIONS = [
+  { icon: '💊', label: '약 등록', path: ROUTE_PATHS.medicationAdd },
+  { icon: '🔍', label: '검색', path: ROUTE_PATHS.search },
+  { icon: '📷', label: '처방전 스캔', path: ROUTE_PATHS.ocrScan },
+]
+
+// 보호자 대시보드 빠른 액션
+export const CAREGIVER_QUICK_ACTIONS = [
+  { icon: '👥', label: '가족 관리', path: ROUTE_PATHS.family },
+  { icon: '💊', label: '약 관리', path: ROUTE_PATHS.medication },
+  { icon: '🔍', label: '검색', path: ROUTE_PATHS.search },
+  { icon: '💬', label: '상담', path: ROUTE_PATHS.chatList },
+]
+
+// 보호자 대시보드 FAB 액션
+export const CAREGIVER_FAB_ACTIONS = [
+  { icon: '👥', label: '가족 초대', path: ROUTE_PATHS.familyInvite },
+  { icon: '💊', label: '약 등록', path: ROUTE_PATHS.medicationAdd },
+  { icon: '🔍', label: '검색', path: ROUTE_PATHS.search },
+]
+
+// 설정 메뉴 정의
+export const SETTINGS_MENU_DEFINITIONS = [
+  {
+    id: 'profile',
+    label: '프로필 편집',
+    icon: '👤',
+    description: '기본 정보 · 연락처 설정',
+    path: ROUTE_PATHS.settingsProfile,
+  },
+  {
+    id: 'notifications',
+    label: '알림 설정',
+    icon: '🔔',
+    description: '푸시 · 이메일 알림 토글',
+    path: ROUTE_PATHS.settingsNotifications,
+  },
+  {
+    id: 'medications',
+    label: '약 관리',
+    icon: '💊',
+    description: '약 목록 · 일정 확인',
+    path: ROUTE_PATHS.medication,
+  },
+  {
+    id: 'diseases',
+    label: '질병 관리',
+    icon: '📋',
+    description: '진단 정보 · 주의 식품',
+    path: ROUTE_PATHS.disease,
+  },
+  {
+    id: 'privacy',
+    label: '개인정보 처리방침',
+    icon: '🔒',
+    path: ROUTE_PATHS.privacyPolicy,
+  },
+  {
+    id: 'terms',
+    label: '이용약관',
+    icon: '📜',
+    path: ROUTE_PATHS.termsOfService,
+  },
+]
+
+// 알림 설정 채널
+export const NOTIFICATION_CHANNELS = [
+  { id: 'push', label: '푸시 알림', description: '앱 푸시로 복약 알림 받기' },
+  { id: 'email', label: '이메일 알림', description: '약 일정 요약 메일' },
+  { id: 'sms', label: 'SMS 알림', description: '긴급 미복약 알림' },
+]
+
+// 프로필 편집 필드
+export const PROFILE_EDIT_FIELDS = [
+  { id: 'name', label: '이름', type: 'text', placeholder: '홍길동' },
+  { id: 'email', label: '이메일', type: 'email', placeholder: 'hong@example.com', readOnly: true },
+  { id: 'phone', label: '전화번호', type: 'tel', placeholder: '010-0000-0000' },
+]
+
+// 멤버 역할 옵션
+export const MEMBER_ROLE_OPTIONS = [
+  { value: 'SENIOR', label: '시니어', icon: '👴' },
+  { value: 'CAREGIVER', label: '보호자', icon: '👨‍👩‍👧' },
+]
+
+// 개발자 프로필
+export const DEV_PROFILES = {
+  SENIOR: {
+    id: 'dev-senior',
+    name: '김어르신',
+    email: 'senior@amapill.dev',
+    customerRole: 'SENIOR',
+    userRole: 'ROLE_USER',
+  },
+  CAREGIVER: {
+    id: 'dev-caregiver',
+    name: '홍보호자',
+    email: 'caregiver@amapill.dev',
+    customerRole: 'CAREGIVER',
+    userRole: 'ROLE_USER',
+  },
+}
+
+export default {
+  SENIOR_QUICK_ACTIONS,
+  SENIOR_FAB_ACTIONS,
+  CAREGIVER_QUICK_ACTIONS,
+  CAREGIVER_FAB_ACTIONS,
+  SETTINGS_MENU_DEFINITIONS,
+  NOTIFICATION_CHANNELS,
+  PROFILE_EDIT_FIELDS,
+  MEMBER_ROLE_OPTIONS,
+  DEV_PROFILES,
+}

--- a/src/devtools/DeveloperModePanel.jsx
+++ b/src/devtools/DeveloperModePanel.jsx
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * DeveloperModePanel
  * - 개발 모드 진입/바로가기 패널 (UI는 SCSS 모듈)
  */
@@ -10,28 +10,10 @@ import { ROUTE_PATHS } from '@config/routes.config'
 import { useAuthStore } from '@features/auth/store/authStore'
 import { resetFamilyMockData } from '@features/family/services/familyService'
 import { MOCK_DIET_LOGS } from '@/data/mockDiet'
+import { DEV_PROFILES } from '@/data/mockUiConstants'
 import styles from './DeveloperModePanel.module.scss'
 
 const DEV_MODE_ENABLED = import.meta.env.VITE_ENABLE_DEV_MODE !== 'false'
-
-const DEFAULT_USER_ROLE = 'ROLE_USER'
-
-const DEV_PROFILES = {
-  [USER_ROLES.SENIOR]: {
-    id: 'dev-senior',
-    name: '김어르신',
-    email: 'senior@amapill.dev',
-    customerRole: USER_ROLES.SENIOR,
-    userRole: DEFAULT_USER_ROLE,
-  },
-  [USER_ROLES.CAREGIVER]: {
-    id: 'dev-caregiver',
-    name: '홍보호자',
-    email: 'caregiver@amapill.dev',
-    customerRole: USER_ROLES.CAREGIVER,
-    userRole: DEFAULT_USER_ROLE,
-  },
-}
 
 const seedDietLogs = () => {
   if (typeof window === 'undefined') return

--- a/src/features/dashboard/pages/CaregiverDashboard.jsx
+++ b/src/features/dashboard/pages/CaregiverDashboard.jsx
@@ -6,6 +6,7 @@ import { useFamilyMemberDetail } from '@features/family/hooks/useFamilyMemberDet
 import MainLayout from '@shared/components/layout/MainLayout'
 import { QuickActions } from '@shared/components/ui/QuickActions'
 import { FAB } from '@shared/components/ui/FAB'
+import { CAREGIVER_QUICK_ACTIONS, CAREGIVER_FAB_ACTIONS } from '@/data/mockUiConstants'
 import styles from './CaregiverDashboard.module.scss'
 
 /**
@@ -37,19 +38,6 @@ export function CaregiverDashboard() {
     navigate(ROUTE_PATHS.familyMemberDetail.replace(':id', memberId))
   }
 
-  const quickActions = [
-    { icon: '👥', label: '가족 관리', path: ROUTE_PATHS.family },
-    { icon: '💊', label: '약 관리', path: ROUTE_PATHS.medication },
-    { icon: '🔍', label: '검색', path: ROUTE_PATHS.search },
-    { icon: '💬', label: '상담', path: ROUTE_PATHS.chatList },
-  ]
-
-  const fabActions = [
-    { icon: '👥', label: '가족 초대', path: ROUTE_PATHS.familyInvite },
-    { icon: '💊', label: '약 등록', path: ROUTE_PATHS.medicationAdd },
-    { icon: '🔍', label: '검색', path: ROUTE_PATHS.search },
-  ]
-
   if (loading && members.length === 0) {
     return (
       <MainLayout userName="보호자" userRole="보호자">
@@ -74,7 +62,7 @@ export function CaregiverDashboard() {
           <p>가족 구성원의 오늘 복약 상태를 빠르게 확인할 수 있습니다.</p>
         </header>
 
-        <QuickActions actions={quickActions} />
+        <QuickActions actions={CAREGIVER_QUICK_ACTIONS} />
 
         <article className={styles.card}>
           <h2>어르신 복약 현황</h2>
@@ -91,7 +79,7 @@ export function CaregiverDashboard() {
           </ul>
         </article>
 
-        <FAB actions={fabActions} />
+        <FAB actions={CAREGIVER_FAB_ACTIONS} />
       </section>
     </MainLayout>
   )

--- a/src/features/dashboard/pages/SeniorDashboard.jsx
+++ b/src/features/dashboard/pages/SeniorDashboard.jsx
@@ -11,7 +11,7 @@ import { FAB } from '@shared/components/ui/FAB'
 import { useFamilyStore } from '@features/family/store/familyStore'
 import { useFamilyMemberDetail } from '@features/family/hooks/useFamilyMemberDetail'
 import { FamilyMockService } from '@features/family/services/familyService'
-import { ROUTE_PATHS } from '@config/routes.config'
+import { SENIOR_QUICK_ACTIONS, SENIOR_FAB_ACTIONS } from '@/data/mockUiConstants'
 import styles from './SeniorDashboard.module.scss'
 
 const mapStatus = (label = '') => {
@@ -91,19 +91,6 @@ export const SeniorDashboard = () => {
     weekday: 'long',
   })
 
-  const quickActions = [
-    { icon: '💊', label: '약 등록', path: ROUTE_PATHS.medicationAdd },
-    { icon: '🔍', label: '검색', path: ROUTE_PATHS.search },
-    { icon: '🍽️', label: '식단 경고', path: ROUTE_PATHS.dietWarning },
-    { icon: '📊', label: '복용 리포트', path: ROUTE_PATHS.adherenceReport },
-  ]
-
-  const fabActions = [
-    { icon: '💊', label: '약 등록', path: ROUTE_PATHS.medicationAdd },
-    { icon: '🔍', label: '검색', path: ROUTE_PATHS.search },
-    { icon: '📷', label: '처방전 스캔', path: ROUTE_PATHS.ocrScan },
-  ]
-
   return (
     <MainLayout userName="어르신" userRole="어르신" notificationCount={0}>
       <div className={styles.dashboardContent}>
@@ -112,7 +99,7 @@ export const SeniorDashboard = () => {
           <p className={styles.dateInfo}>{todayDate}</p>
         </div>
 
-        <QuickActions actions={quickActions} />
+        <QuickActions actions={SENIOR_QUICK_ACTIONS} />
 
         <div className={styles.medicationList}>
           {scheduleList.map((schedule) => (
@@ -124,7 +111,7 @@ export const SeniorDashboard = () => {
           ))}
         </div>
 
-        <FAB actions={fabActions} />
+        <FAB actions={SENIOR_FAB_ACTIONS} />
       </div>
     </MainLayout>
   )

--- a/src/features/family/components/MemberRoleSelector.jsx
+++ b/src/features/family/components/MemberRoleSelector.jsx
@@ -1,14 +1,10 @@
+import { MEMBER_ROLE_OPTIONS } from '@/data/mockUiConstants'
 import styles from './MemberRoleCard.module.scss'
-
-const ROLE_OPTIONS = [
-  { value: 'SENIOR', label: '시니어', icon: '👴' },
-  { value: 'CAREGIVER', label: '보호자', icon: '👨‍👩‍👧' },
-]
 
 export const MemberRoleSelector = ({ value, onChange, disabled }) => {
   return (
     <div className={styles.roleSelector}>
-      {ROLE_OPTIONS.map((option) => {
+      {MEMBER_ROLE_OPTIONS.map((option) => {
         const active = value === option.value
         return (
           <button

--- a/src/features/notification/store/notificationStore.js
+++ b/src/features/notification/store/notificationStore.js
@@ -4,16 +4,19 @@
  */
 
 import { create } from 'zustand'
+import { MOCK_NOTIFICATIONS } from '@/data/mockNotifications'
 
-// Mock 데이터 (추후 API 연동)
-const mockNotifications = [
-  { id: 1, title: '복약 알림', message: '아침 약 복용 시간입니다', read: false, createdAt: new Date() },
-  { id: 2, title: '가족 알림', message: '어머니가 약을 복용했습니다', read: false, createdAt: new Date() },
-  { id: 3, title: '식이 경고', message: '자몽 주스 섭취 주의', read: true, createdAt: new Date() },
-]
+// MOCK_NOTIFICATIONS를 store 형식으로 변환
+const initialNotifications = MOCK_NOTIFICATIONS.map((n) => ({
+  id: n.id,
+  title: n.title,
+  message: n.message,
+  read: n.status === 'READ',
+  createdAt: new Date(n.createdAt),
+}))
 
 export const useNotificationStore = create((set, get) => ({
-  notifications: mockNotifications,
+  notifications: initialNotifications,
   loading: false,
   error: null,
 
@@ -28,7 +31,7 @@ export const useNotificationStore = create((set, get) => ({
     try {
       // TODO: API 호출
       // const notifications = await notificationApi.getAll()
-      set({ notifications: mockNotifications, loading: false })
+      set({ notifications: initialNotifications, loading: false })
     } catch (error) {
       set({ error, loading: false })
     }

--- a/src/features/report/pages/AdherenceReportPage.jsx
+++ b/src/features/report/pages/AdherenceReportPage.jsx
@@ -6,6 +6,7 @@
 
 import MainLayout from '@shared/components/layout/MainLayout'
 import { BackButton } from '@shared/components/ui/BackButton'
+import { MOCK_ADHERENCE_PAGE_DATA, MOCK_RECENT_HISTORY } from '@/data/mockReports'
 import styles from './AdherenceReportPage.module.scss'
 
 /**
@@ -13,27 +14,9 @@ import styles from './AdherenceReportPage.module.scss'
  * @returns {JSX.Element}
  */
 export const AdherenceReportPage = () => {
-  // Mock data - 실제로는 API에서 가져올 데이터
-  const adherenceData = {
-    overall: 87,
-    thisWeek: 92,
-    lastWeek: 85,
-    thisMonth: 87,
-    streak: 14, // 연속 복용일
-    totalDays: 90,
-    completedDays: 78,
-    missedDays: 12,
-  }
-
-  const recentHistory = [
-    { date: '2025-01-18', status: 'completed', count: 3, total: 3 },
-    { date: '2025-01-17', status: 'completed', count: 3, total: 3 },
-    { date: '2025-01-16', status: 'partial', count: 2, total: 3 },
-    { date: '2025-01-15', status: 'completed', count: 3, total: 3 },
-    { date: '2025-01-14', status: 'missed', count: 1, total: 3 },
-    { date: '2025-01-13', status: 'completed', count: 3, total: 3 },
-    { date: '2025-01-12', status: 'completed', count: 3, total: 3 },
-  ]
+  // TODO: API 연동 시 실제 데이터로 교체
+  const adherenceData = MOCK_ADHERENCE_PAGE_DATA
+  const recentHistory = MOCK_RECENT_HISTORY
 
   const getStatusLabel = (status) => {
     switch (status) {

--- a/src/features/settings/pages/Notifications/NotificationSettings.jsx
+++ b/src/features/settings/pages/Notifications/NotificationSettings.jsx
@@ -1,11 +1,6 @@
 import MainLayout from '@shared/components/layout/MainLayout'
+import { NOTIFICATION_CHANNELS } from '@/data/mockUiConstants'
 import styles from './NotificationSettings.module.scss'
-
-const channels = [
-  { id: 'push', label: '푸시 알림', description: '앱 푸시로 복약 알림 받기' },
-  { id: 'email', label: '이메일 알림', description: '약 일정 요약 메일' },
-  { id: 'sms', label: 'SMS 알림', description: '긴급 미복약 알림' },
-]
 
 export const NotificationSettingsPage = () => {
   return (
@@ -17,7 +12,7 @@ export const NotificationSettingsPage = () => {
         </header>
 
         <section className={styles.channelList}>
-          {channels.map((channel) => (
+          {NOTIFICATION_CHANNELS.map((channel) => (
             <label key={channel.id} className={styles.channelItem}>
               <div>
                 <p className={styles.label}>{channel.label}</p>

--- a/src/features/settings/pages/Profile/ProfileEdit.jsx
+++ b/src/features/settings/pages/Profile/ProfileEdit.jsx
@@ -1,11 +1,6 @@
 import MainLayout from '@shared/components/layout/MainLayout'
+import { PROFILE_EDIT_FIELDS } from '@/data/mockUiConstants'
 import styles from './ProfileEdit.module.scss'
-
-const mockFields = [
-  { id: 'name', label: '이름', type: 'text', placeholder: '홍길동' },
-  { id: 'email', label: '이메일', type: 'email', placeholder: 'hong@example.com', readOnly: true },
-  { id: 'phone', label: '전화번호', type: 'tel', placeholder: '010-0000-0000' },
-]
 
 export const ProfileEditPage = () => {
   return (
@@ -17,7 +12,7 @@ export const ProfileEditPage = () => {
         </header>
 
         <form className={styles.form}>
-          {mockFields.map((field) => (
+          {PROFILE_EDIT_FIELDS.map((field) => (
             <label key={field.id} className={styles.formGroup}>
               <span>{field.label}</span>
               <input

--- a/src/features/settings/pages/Settings.jsx
+++ b/src/features/settings/pages/Settings.jsx
@@ -1,53 +1,11 @@
-﻿import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import MainLayout from '@shared/components/layout/MainLayout'
 import { ProfileSection } from '../components/ProfileSection.jsx'
 import { SettingsMenu } from '../components/SettingsMenu.jsx'
 import { useAuth } from '@features/auth/hooks/useAuth'
 import { ROUTE_PATHS } from '@config/routes.config'
+import { SETTINGS_MENU_DEFINITIONS } from '@/data/mockUiConstants'
 import styles from './Settings.module.scss'
-
-const menuDefinitions = [
-  {
-    id: 'profile',
-    label: '프로필 편집',
-    icon: '👤',
-    description: '기본 정보 · 연락처 설정',
-    path: ROUTE_PATHS.settingsProfile,
-  },
-  {
-    id: 'notifications',
-    label: '알림 설정',
-    icon: '🔔',
-    description: '푸시 · 이메일 알림 토글',
-    path: ROUTE_PATHS.settingsNotifications,
-  },
-  {
-    id: 'medications',
-    label: '약 관리',
-    icon: '💊',
-    description: '약 목록 · 일정 확인',
-    path: ROUTE_PATHS.medication,
-  },
-  {
-    id: 'diseases',
-    label: '질병 관리',
-    icon: '📋',
-    description: '진단 정보 · 주의 식품',
-    path: ROUTE_PATHS.disease,
-  },
-  {
-    id: 'privacy',
-    label: '개인정보 처리방침',
-    icon: '🔒',
-    path: ROUTE_PATHS.privacyPolicy,
-  },
-  {
-    id: 'terms',
-    label: '이용약관',
-    icon: '📜',
-    path: ROUTE_PATHS.termsOfService,
-  },
-]
 
 export const SettingsPage = () => {
   const navigate = useNavigate()
@@ -59,7 +17,7 @@ export const SettingsPage = () => {
   }
 
   const items = [
-    ...menuDefinitions.map((item) => ({ ...item, onClick: () => handleNavigate(item.path) })),
+    ...SETTINGS_MENU_DEFINITIONS.map((item) => ({ ...item, onClick: () => handleNavigate(item.path) })),
     {
       id: 'logout',
       label: '로그아웃',


### PR DESCRIPTION
- 하드코딩된 mock 데이터를 /src/data로 이동
- chatApiClient.js: mockChat.js에서 데이터 import
- ocrApiClient.js: mockOcr.js에서 데이터 import
- AdherenceReportPage: mockReports.js에서 데이터 import
- notificationStore: mockNotifications.js에서 데이터 import
- Dashboard 컴포넌트들: mockUiConstants.js에서 UI 상수 import
- Settings 컴포넌트들: mockUiConstants.js에서 UI 상수 import
- DevTools: mockUiConstants.js에서 DEV_PROFILES import
- 새 파일 mockUiConstants.js 추가 (UI 상수 통합 관리)

