### PR TITLE
🔒 Fix: Family Store 인증 체크 추가

### DIFF
--- a/src/features/family/context/FamilyContext.jsx
+++ b/src/features/family/context/FamilyContext.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { useFamilyStore } from '@features/family/store/familyStore'
 import { FamilyContext } from './familyContextObject'
+import { STORAGE_KEYS } from '@config/constants'
 
 export const FamilyProvider = ({ children }) => {
   const initialize = useFamilyStore((state) => state.initialize)
@@ -9,7 +10,9 @@ export const FamilyProvider = ({ children }) => {
   const members = useFamilyStore((state) => state.members)
 
   useEffect(() => {
-    if (!isInitialized) {
+    // 토큰이 있을 때만 초기화
+    const token = window.localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN)
+    if (token && !isInitialized) {
       initialize()
     }
   }, [initialize, isInitialized])

--- a/src/features/family/store/familyStore.js
+++ b/src/features/family/store/familyStore.js
@@ -9,6 +9,7 @@ import {
   DEFAULT_FAMILY_MEMBERS,
 } from '@/data/mockFamily'
 import { familyApiClient } from '@core/services/api/familyApiClient'
+import { STORAGE_KEYS } from '@config/constants'
 
 const initialState = {
   familyGroup: DEFAULT_FAMILY_GROUP,
@@ -40,7 +41,16 @@ export const useFamilyStore = create((set, get) => ({
   ...initialState,
 
   initialize: async ({ force } = {}) => {
+    // 1. 토큰 확인 - 없으면 초기화 스킵 (로그인 전)
+    const token = window.localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN)
+    if (!token) {
+      return
+    }
+
+    // 2. 이미 초기화됐으면 스킵 (force true면 재초기화)
     if (get().initialized && !force) return
+
+    // 3. 가족 데이터 로드
     await get().loadFamily()
   },
 


### PR DESCRIPTION
## 요약
로그인/회원가입 페이지에서 발생하던 401 Unauthorized 에러를 제거했습니다.
Family Store에서 토큰 확인 후에만 API를 호출하도록 개선했습니다.

## 변경사항
- `src/features/family/store/familyStore.js`: initialize() 메서드에 토큰 체크 추가
- `src/features/family/context/FamilyContext.jsx`: useEffect에 토큰 체크 추가

## 문서 업데이트
- ✅ `aidocs/shadow/api/family.md`: 인증 요구사항 추가
- ✅ `aidocs/FRONTEND_WORKFLOW.md`: 토큰 체크 패턴 문서화
- ✅ `aidocs/decisions/frontend/2025-11-23_family_store_auth_check.md`: 의사결정 한글 번역 완료

## 테스트 방법
- [x] 로그인 페이지 접속 - 콘솔에 401 에러 없음 확인
- [x] 회원가입 페이지 접속 - 콘솔에 401 에러 없음 확인
- [ ] 로그인 후 대시보드 - 가족 데이터 정상 로드 확인
- [ ] 가족 초대 링크로 회원가입 - 토큰 획득 후 자동 초기화 확인

## 관련 의사결정
- `aidocs/decisions/frontend/2025-11-23_family_store_auth_check.md`

## 빌드 상태
- ✅ 코드 품질: 깔끈한 코드, 불필요한 import 없음
- ⏳ 프론트엔드 빌드: `npm run build` 테스트 필요