### PR TITLE
🐞 Fix: 가족 관리 UI 권한/해산/버튼 표시 보완 (#38)

### DIFF
--- a/src/features/family/components/FamilyMemberCard.jsx
+++ b/src/features/family/components/FamilyMemberCard.jsx
@@ -12,10 +12,17 @@ export const FamilyMemberCard = ({
   onRemove,
   isOnline,
   isRemoving,
+  currentUserId,
+  groupOwnerId,
 }) => {
   if (!member) return null
   const initials = member.name?.[0] ?? 'U'
   const joinedDate = new Date(member.joinedAt).toLocaleDateString('ko-KR')
+
+  const isSelf = member.userId?.toString?.() === currentUserId?.toString?.()
+  const isOwner = groupOwnerId != null && member.userId?.toString?.() === groupOwnerId?.toString?.()
+  const showRemove = !isOwner || !isSelf
+  const removeLabel = isSelf && !isOwner ? '탈퇴' : '제거'
 
   return (
     <div className={styles.card}>
@@ -37,15 +44,17 @@ export const FamilyMemberCard = ({
         <button type="button" className={styles.detailButton} onClick={() => onDetail?.(member.id)}>
           상세
         </button>
-        <button
-          type="button"
-          className={styles.removeButton}
-          onClick={() => onRemove?.(member.id)}
-          disabled={isRemoving}
-          aria-busy={isRemoving}
-        >
-          {isRemoving ? '제거 중...' : '제거'}
-        </button>
+        {showRemove && (
+          <button
+            type="button"
+            className={styles.removeButton}
+            onClick={() => onRemove?.(member.id)}
+            disabled={isRemoving}
+            aria-busy={isRemoving}
+          >
+            {isRemoving ? `${removeLabel} 중...` : removeLabel}
+          </button>
+        )}
       </div>
     </div>
   )
@@ -59,16 +68,21 @@ FamilyMemberCard.propTypes = {
     role: PropTypes.oneOf(['SENIOR', 'CAREGIVER']).isRequired,
     joinedAt: PropTypes.string.isRequired,
     avatarColor: PropTypes.string,
+    userId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   }).isRequired,
   onDetail: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   isOnline: PropTypes.bool,
   isRemoving: PropTypes.bool,
+  currentUserId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  groupOwnerId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 
 FamilyMemberCard.defaultProps = {
   isOnline: false,
   isRemoving: false,
+  currentUserId: null,
+  groupOwnerId: null,
 }
 
 export default FamilyMemberCard

--- a/src/features/family/components/FamilyMemberList.jsx
+++ b/src/features/family/components/FamilyMemberList.jsx
@@ -7,6 +7,8 @@ export const FamilyMemberList = ({
   onRemove,
   onlineMemberIds = [],
   removingMemberId,
+  currentUserId,
+  groupOwnerId,
 }) => {
   if (!members.length) {
     return (
@@ -29,6 +31,8 @@ export const FamilyMemberList = ({
             onRemove={onRemove}
             isOnline={onlineMemberIds.includes(member.id)}
             isRemoving={removingMemberId === member.id}
+            currentUserId={currentUserId}
+            groupOwnerId={groupOwnerId}
           />
         ))}
       </div>

--- a/src/features/family/hooks/useFamilyMemberDetail.js
+++ b/src/features/family/hooks/useFamilyMemberDetail.js
@@ -1,11 +1,32 @@
 import { useQuery } from '@tanstack/react-query'
-import { FamilyMockService } from '../services/familyService'
+import { useFamilyStore } from '../store/familyStore'
 
+/**
+ * 가족 구성원 상세 (프론트 로컬 스토어 기반)
+ * 백엔드에서 별도 상세 API가 없으므로, 이미 로드된 members 배열에서 찾아 반환한다.
+ */
 export const useFamilyMemberDetail = (memberId) => {
+  const members = useFamilyStore((state) => state.members || [])
+
   return useQuery({
-    queryKey: ['family', 'member', memberId],
+    queryKey: ['family', 'member', memberId, members],
     enabled: Boolean(memberId),
-    queryFn: () => FamilyMockService.getMemberDetail(memberId),
+    staleTime: 60 * 1000,
+    queryFn: async () => {
+      const target = members.find(
+        (m) => m?.id?.toString() === memberId?.toString(),
+      )
+      if (!target) {
+        throw new Error('구성원을 찾을 수 없습니다.')
+      }
+
+      // 상세 데이터(복약/순응도)는 아직 목 기반이므로 비워둔다.
+      return {
+        member: target,
+        medications: [],
+        adherence: 0,
+      }
+    },
   })
 }
 

--- a/src/features/family/pages/FamilyManagement.module.scss
+++ b/src/features/family/pages/FamilyManagement.module.scss
@@ -173,3 +173,12 @@
     cursor: not-allowed;
   }
 }
+
+.dangerButton {
+  @extend .confirmButton;
+  background: #dc2626;
+
+  &:hover {
+    background: #b91c1c;
+  }
+}


### PR DESCRIPTION



      ## 🔗 관련 이슈
      <!-- 관련된 이슈가 있다면 링크해주세요 -->
      Closes # 38
      Related to #
    ## 요약
    - 그룹 오너만 해산 버튼 노출 및 해산 동작 추가
    - 구성원 버튼 표시 개선: 오너 카드 숨김, 본인은 ‘탈퇴’, 기타는 ‘제거’
    - 멤버/그룹 응답 정규화 보강(createdBy/userId 포함)

    ## 주요 변경
    - familyApiClient: createdBy/userId 정규화
    - FamilyMemberCard/List: 현재 사용자/오너 기반 버튼 렌더링
    - FamilyManagement: 해산 액션/모달 추가, 진행 로딩 처리
    - 스타일: dangerButton 추가
    - 상세 훅: 스토어 기반 멤버 조회로 실제 데이터 사용

    ## 테스트
    - [ ] UI 수동 확인만(로컬 빌드/자동 테스트 미실행, 요청 시 진행)