### PR TITLE
fix: Improve family invite flow and management logic (#57)

### DIFF
--- a/src/core/services/api/familyApiClient.js
+++ b/src/core/services/api/familyApiClient.js
@@ -59,7 +59,26 @@ class FamilyApiClient extends ApiClient {
   }
 
   createGroup(name) {
-    return this.post('/groups', { name })
+    return this.post('/groups', { name }).then((group) => {
+      // Normalize the created group to match getSummary structure
+      return {
+        id: group?.id,
+        name: group?.name,
+        createdBy: group?.createdBy?.id ?? group?.createdBy,
+        createdAt: group?.createdAt,
+        members: Array.isArray(group?.members)
+          ? group.members.map((member) => ({
+              id: member?.id?.toString() ?? member?.userId?.toString(),
+              userId: member?.user?.id ?? member?.userId ?? (typeof member?.id === 'number' ? member.id : null),
+              name: member?.user?.name || member?.userName || '이름 없음',
+              email: member?.user?.email || member?.userEmail || '',
+              role: member?.familyRole || member?.user?.customerRole || member?.userRole || 'SENIOR',
+              joinedAt: member?.joinedAt || new Date().toISOString(),
+              raw: member,
+            }))
+          : [],
+      }
+    })
   }
 
   deleteGroup(groupId) {

--- a/src/features/family/components/FamilyGroupCard.jsx
+++ b/src/features/family/components/FamilyGroupCard.jsx
@@ -10,6 +10,14 @@ export const FamilyGroupCard = ({ group, memberCount = 0 }) => {
     day: 'numeric',
   })
 
+  // [Fixed] createdBy is an ID, find name from members
+  const creator = group.members?.find(
+    (m) =>
+      String(m.id) === String(group.createdBy) ||
+      String(m.userId) === String(group.createdBy),
+  )
+  const creatorName = creator?.name || group.createdBy?.name || '알 수 없음'
+
   return (
     <section className={styles.card}>
       <div className={styles.header}>
@@ -17,7 +25,7 @@ export const FamilyGroupCard = ({ group, memberCount = 0 }) => {
         <span className={styles.badge}>{memberCount}명 참여</span>
       </div>
       <div className={styles.meta}>
-        <span>생성자: {group.createdBy?.name}</span>
+        <span>생성자: {creatorName}</span>
         <span>생성일: {createdDate}</span>
       </div>
     </section>
@@ -26,13 +34,18 @@ export const FamilyGroupCard = ({ group, memberCount = 0 }) => {
 
 FamilyGroupCard.propTypes = {
   group: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-    createdAt: PropTypes.string.isRequired,
-    createdBy: PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-    }),
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    name: PropTypes.string,
+    createdAt: PropTypes.string,
+    createdBy: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.shape({
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        name: PropTypes.string,
+      }),
+    ]),
+    members: PropTypes.arrayOf(PropTypes.object),
   }).isRequired,
   memberCount: PropTypes.number,
 }

--- a/src/features/family/components/FamilyMemberCard.jsx
+++ b/src/features/family/components/FamilyMemberCard.jsx
@@ -19,10 +19,20 @@ export const FamilyMemberCard = ({
   const initials = member.name?.[0] ?? 'U'
   const joinedDate = new Date(member.joinedAt).toLocaleDateString('ko-KR')
 
-  const isSelf = member.userId?.toString?.() === currentUserId?.toString?.()
-  const isOwner = groupOwnerId != null && member.userId?.toString?.() === groupOwnerId?.toString?.()
-  const showRemove = !isOwner || !isSelf
-  const removeLabel = isSelf && !isOwner ? '탈퇴' : '제거'
+  const isCardSelf = member.userId?.toString?.() === currentUserId?.toString?.()
+  const isCardGroupOwner =
+    groupOwnerId != null && member.userId?.toString?.() === groupOwnerId?.toString?.()
+  const isViewerGroupOwner =
+    currentUserId != null &&
+    groupOwnerId != null &&
+    currentUserId?.toString?.() === groupOwnerId?.toString?.()
+
+  // 1. 관리자(ViewerOwner)는 본인 제외 다른 사람 제거 가능
+  // 2. 일반 멤버는 본인만 탈퇴 가능 (단, 그룹장이면 탈퇴 불가 -> 해산 이용)
+  const showRemove =
+    (isViewerGroupOwner && !isCardSelf) || (isCardSelf && !isCardGroupOwner)
+
+  const removeLabel = isCardSelf ? '탈퇴' : '제거'
 
   return (
     <div className={styles.card}>

--- a/src/features/family/hooks/useFamilySync.js
+++ b/src/features/family/hooks/useFamilySync.js
@@ -12,14 +12,23 @@ import { FamilySyncService } from '../services/familySyncService'
 
 export const useFamilySync = () => {
   const {
-    familyGroup,
-    members,
+    familyGroups,
+    selectedGroupId,
     inviteMember,
     removeMember,
     refetchFamily,
     loading,
     error,
   } = useFamily()
+  
+  // [Fixed] Derive current familyGroup from store state
+  const familyGroup = useMemo(() => {
+    return familyGroups?.find((g) => g.id === selectedGroupId) || null
+  }, [familyGroups, selectedGroupId])
+
+  // [Fixed] Derive members from the selected family group
+  const members = useMemo(() => familyGroup?.members || [], [familyGroup])
+
   const { user, token } = useAuth((state) => ({
     user: state.user,
     token: state.token,

--- a/src/features/family/pages/FamilyManagement.jsx
+++ b/src/features/family/pages/FamilyManagement.jsx
@@ -15,7 +15,8 @@ import styles from './FamilyManagement.module.scss'
 
 export const FamilyManagementPage = () => {
   const navigate = useNavigate()
-  const currentUserId = useAuthStore((state) => state.user?.id)
+  // [Fixed] Resolve user ID from either id or userId to handle different auth response structures
+  const currentUserId = useAuthStore((state) => state.user?.id || state.user?.userId)
   const familyGroups = useFamilyStore((state) => state.familyGroups)
   const selectedGroupId = useFamilyStore((state) => state.selectedGroupId)
   const getSelectedGroup = useFamilyStore((state) => state.getSelectedGroup)
@@ -131,6 +132,8 @@ export const FamilyManagementPage = () => {
                     try {
                       await removeMember(memberId)
                       toast.success('구성원이 제거되었습니다.')
+                      await refetchFamily?.() // Add this line to refetch family data
+
                     } catch (error) {
                       toast.error('구성원 제거에 실패했습니다. 다시 시도해 주세요.')
                       console.warn('[FamilyManagement] removeMember failed', error)


### PR DESCRIPTION
## ✨ PR 요약
가족 초대 및 그룹 관리 페이지의 UI/UX 버그를 수정하고, API 연동 안정성을 강화했습니다. 불필요한 테스트용 "빠른 초대 코드" 기능을 제거했습니다.

## 🔗 관련 이슈
Closes #57

## 🛠️ 변경 내용
- **`Front/src/features/family/pages/FamilyManagement.jsx`**: 
  - 멤버 제거 후 `refetchFamily()` 호출 추가로 UI 동기화 보장.
  - `currentUserId` 추출 로직 개선 (`id` || `userId`)으로 그룹 해산 버튼 표시 정상화.
- **`Front/src/features/family/components/FamilyGroupCard.jsx`**: 
  - 그룹 생성자 이름 표시 로직 수정 (ID로 멤버 목록 검색).
- **`Front/src/features/family/hooks/useFamilySync.js`**: 
  - `familyGroup`을 `familyGroups` 배열에서 `selectedGroupId`로 찾도록 수정.
  - `members` 변수에 `useMemo` 적용하여 무한 렌더링 방지.
- **`Front/src/features/family/pages/FamilyInvite.jsx`**: 
  - `familyGroup` 파생 로직 수정으로 초대 기능 활성화.
  - "빠른 초대 코드 생성" 관련 코드 및 UI 제거.
- **`Front/src/core/services/api/familyApiClient.js`**: 
  - `acceptInvite` API 경로를 `/invites/accept`로 원복.
- **`Front/src/features/family/components/FamilyMemberCard.jsx`**:
  - 제거 버튼 표시 권한 로직 수정 (생성자만 다른 멤버 제거 가능, 일반 멤버는 본인만 탈퇴 가능).

## ✅ 체크리스트
- [x] 코드가 스타일 가이드라인을 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [ ] 주석을 추가했습니다 (특히 복잡한 로직).
- [x] 관련 이슈를 링크했습니다.
- [x] 커밋 메시지가 명확합니다.

## 🙋 리뷰어에게
`useFamilySync.js`의 `members` 의존성 배열 수정으로 인한 사이드 이펙트가 없는지 확인 부탁드립니다.
백엔드 API 변경 사항(`FamilyInviteController` 추가)과 함께 배포되어야 정상 동작합니다.
