### PR TITLE
✨ Feat: 가족 초대 실시간 업데이트 및 목록 갱신 수정 (#83)

### DIFF
--- a/src/core/services/api/familyApiClient.js
+++ b/src/core/services/api/familyApiClient.js
@@ -68,14 +68,14 @@ class FamilyApiClient extends ApiClient {
         createdAt: group?.createdAt,
         members: Array.isArray(group?.members)
           ? group.members.map((member) => ({
-              id: member?.id?.toString() ?? member?.userId?.toString(),
-              userId: member?.user?.id ?? member?.userId ?? (typeof member?.id === 'number' ? member.id : null),
-              name: member?.user?.name || member?.userName || '이름 없음',
-              email: member?.user?.email || member?.userEmail || '',
-              role: member?.familyRole || member?.user?.customerRole || member?.userRole || 'SENIOR',
-              joinedAt: member?.joinedAt || new Date().toISOString(),
-              raw: member,
-            }))
+            id: member?.id?.toString() ?? member?.userId?.toString(),
+            userId: member?.user?.id ?? member?.userId ?? (typeof member?.id === 'number' ? member.id : null),
+            name: member?.user?.name || member?.userName || '이름 없음',
+            email: member?.user?.email || member?.userEmail || '',
+            role: member?.familyRole || member?.user?.customerRole || member?.userRole || 'SENIOR',
+            joinedAt: member?.joinedAt || new Date().toISOString(),
+            raw: member,
+          }))
           : [],
       }
     })
@@ -85,8 +85,9 @@ class FamilyApiClient extends ApiClient {
     return this.delete(`/groups/${groupId}`)
   }
 
-  getInvites() {
-    return this.get('/invites')
+  getInvites(groupId) {
+    const query = groupId ? `?groupId=${groupId}` : ''
+    return this.get(`/invites${query}`)
   }
 
   inviteMember(payload) {

--- a/src/core/services/api/notificationApiClient.js
+++ b/src/core/services/api/notificationApiClient.js
@@ -88,6 +88,21 @@ class NotificationApiClient extends ApiClient {
             }
         })
 
+        // invite.accepted 이벤트 리스너 추가
+        this.eventSource.addEventListener('invite.accepted', (event) => {
+            try {
+                const data = JSON.parse(event.data)
+                if (onMessage) {
+                    onMessage({ ...data, type: 'invite.accepted' })
+                }
+            } catch (error) {
+                console.error('Failed to parse invite.accepted event:', error)
+                if (onError) {
+                    onError(error)
+                }
+            }
+        })
+
         // Handle connection errors
         this.eventSource.onerror = (error) => {
             console.error('SSE connection error:', error)

--- a/src/features/family/pages/FamilyInvite.jsx
+++ b/src/features/family/pages/FamilyInvite.jsx
@@ -45,7 +45,9 @@ export const FamilyInvitePage = () => {
   const [acceptingId, setAcceptingId] = useState(null)
   const [regenerating, setRegenerating] = useState(false)
 
-  const sentInvites = useMemo(() => invites?.sent || [], [invites])
+  const sentInvites = useMemo(() => {
+    return (invites?.sent || []).filter((inv) => inv.status === 'PENDING')
+  }, [invites])
   const receivedInvites = useMemo(() => invites?.received || [], [invites])
   const hasGroup = Boolean(familyGroup?.id)
 
@@ -140,7 +142,6 @@ export const FamilyInvitePage = () => {
     setCancelingId(inviteId)
     try {
       await cancelInvite?.(inviteId)
-      await loadInvites?.()
       toast.success('초대가 취소되었습니다.')
     } catch (error) {
       console.warn('[FamilyInvite] cancelInvite failed', error)
@@ -266,7 +267,7 @@ export const FamilyInvitePage = () => {
               return (
                 <li key={inviteId}>
                   <div className={styles.inviteMeta}>
-                    <span className={styles.email}>{invite.inviteeEmail || '이메일 미지정'}</span>
+                    <span className={styles.email}>{invite.intendedForEmail || invite.inviteeEmail || '이메일 미지정'}</span>
                     <span className={styles.role}>{invite.suggestedRole || '역할 미정'}</span>
                     {invite.expiresAt && (
                       <span className={styles.expiry}>

--- a/src/features/notification/hooks/useNotificationStream.js
+++ b/src/features/notification/hooks/useNotificationStream.js
@@ -45,6 +45,14 @@ export const useNotificationStream = (onNotification) => {
           })
           break
 
+        case 'invite.accepted':
+          // 초대 수락 알림 - 보낸 초대 목록에서 제거
+          import('@features/family/store/familyStore').then(({ useFamilyStore }) => {
+            useFamilyStore.getState().removeInviteById(data.inviteId)
+          })
+          toast.success(data.message || '초대가 수락되었습니다')
+          break
+
         default:
           // 기타 알림 (정보 토스트)
           toast.info(data.message || '새로운 알림이 있습니다')


### PR DESCRIPTION
## ✨ PR 요약
가족 초대 수락 시 "보낸 초대" 목록이 실시간으로 업데이트되지 않는 문제를 해결했습니다.
SSE 이벤트를 수신하여 스토어 상태를 즉시 갱신하도록 수정했습니다.

## 🔗 관련 이슈
Closes #83


## 🛠️ 변경 내용
- **`notificationApiClient.js`**: `invite.accepted` SSE 이벤트 리스너 추가.
- **`useNotificationStream.js`**: 이벤트 수신 시 로그 추가 및 스토어 업데이트 로직 확인.
- **`familyApiClient.js`**: `getInvites` 호출 시 `groupId` 파라미터 지원 추가 (목록 필터링 강화).
- **`FamilyInvite.jsx`**:
    - 이메일 표시 로직 개선 (`intendedForEmail` 우선 사용).
    - `PENDING` 상태 필터링 추가.
    - 초대 취소 시 낙관적 업데이트 적용 (불필요한 리로드 제거).

## ✅ 체크리스트
- [x] 코드가 스타일 가이드라인을 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 주석을 추가했습니다 (특히 복잡한 로직).
- [x] 관련 이슈를 링크했습니다.
- [x] 커밋 메시지가 명확합니다.

## 🙋 리뷰어에게
`invite.accepted` 이벤트가 발생하면 `removeInviteById`가 호출되어 목록에서 즉시 제거됩니다.
