### PR TITLE
🐛 Fix: 초기 로딩 401 에러 및 SSE 루프 수정 (#85)

### DIFF
--- a/src/features/family/context/FamilyContext.jsx
+++ b/src/features/family/context/FamilyContext.jsx
@@ -13,6 +13,7 @@ const PUBLIC_PATHS = new Set([
   ROUTE_PATHS.inviteAccept,
   ROUTE_PATHS.privacyPolicy,
   ROUTE_PATHS.termsOfService,
+  ROUTE_PATHS.root,
 ])
 
 export const FamilyProvider = ({ children }) => {

--- a/src/features/notification/hooks/useNotificationStream.js
+++ b/src/features/notification/hooks/useNotificationStream.js
@@ -11,15 +11,28 @@ import { useAuthStore } from '@features/auth/store/authStore'
 import { useNotificationStore } from '@features/notification/store/notificationStore'
 import { notificationApiClient } from '@core/services/api/notificationApiClient'
 import { toast } from '@shared/components/toast/toastStore'
+import { useLocation } from 'react-router-dom'
+import { ROUTE_PATHS } from '@config/routes.config'
+
+const PUBLIC_PATHS = new Set([
+  ROUTE_PATHS.login,
+  ROUTE_PATHS.signup,
+  ROUTE_PATHS.root,
+  ROUTE_PATHS.inviteCodeEntry,
+  ROUTE_PATHS.inviteAccept,
+  ROUTE_PATHS.kakaoCallback,
+])
 
 export const useNotificationStream = (onNotification) => {
   const token = useAuthStore((state) => state.token)
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const addRealtimeNotification = useNotificationStore((state) => state.addRealtimeNotification)
+  const location = useLocation()
 
   useEffect(() => {
-    // SSE 연결 조건: 인증되었고 토큰이 있어야 함
-    if (!isAuthenticated || !token) {
+    // SSE 연결 조건: 인증되었고 토큰이 있어야 함, 그리고 public 페이지가 아니어야 함
+    const isPublic = PUBLIC_PATHS.has(location.pathname)
+    if (!isAuthenticated || !token || isPublic) {
       return
     }
 
@@ -75,5 +88,5 @@ export const useNotificationStream = (onNotification) => {
     return () => {
       notificationApiClient.disconnect()
     }
-  }, [isAuthenticated, token, onNotification, addRealtimeNotification])
+  }, [isAuthenticated, token, onNotification, addRealtimeNotification, location.pathname])
 }


### PR DESCRIPTION
## ✨ PR 요약

앱 초기 구동 시 발생하는 401 에러 및 인증 실패 시 무한 루프에 빠지는 현상을 수정합니다.
공개 경로(Public Paths)에서의 불필요한 인증 체크 및 SSE 연결 시도를 방지하여 초기 로딩 안정성을 확보했습니다.

## 🔗 관련 이슈

Closes #85

## 🛠️ 변경 내용

### 1. 공개 경로 인증 예외 처리 (`FamilyContext.jsx`)

- `PUBLIC_PATHS` 목록에 `ROUTE_PATHS.root` ('/') 추가
- 초기 진입 시 불필요한 `loadFamily` 호출 방지

### 2. 알림 스트림 연결 제어 (`useNotificationStream.js`)

- `useNotificationStream` 훅 내부에 경로 확인 로직 추가
- 현재 경로가 `PUBLIC_PATHS`에 포함될 경우 SSE 연결을 시도하지 않도록 수정 (`invite` 페이지 등에서의 401 루프 방지)

## ✅ 체크리스트

- [x] 코드가 스타일 가이드라인을 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 관련 이슈를 링크했습니다.
- [x] 커밋 메시지가 명확합니다.

## 🙋 리뷰어에게

- 초기 진입 시(`ROOT` 경로) 및 초대 코드 입력 페이지(`invite`)에서 401 에러가 발생하지 않는지 확인 부탁드립니다.
- 로그인 상태와 비로그인 상태 각각에서 라우팅이 정상적으로 동작하는지 테스트가 필요합니다.
