### PR TITLE
 Feat: Update Family Invite UX (Closes #87)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@
 import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom'
 import { useEffect } from 'react'
 import { ROUTE_PATHS } from '@config/routes.config'
+import { useAuth } from '@features/auth/hooks/useAuth'
 import { FamilyProvider } from '@features/family/context/FamilyContext'
 import { PrivateRoute } from './core/routing/PrivateRoute'
 import { Login } from '@features/auth/pages/Login'
@@ -73,6 +74,31 @@ function NavigationRegistrar() {
     setNavigator(navigate)
   }, [navigate])
   return null
+}
+
+/**
+ * 루트 경로 리다이렉트 컴포넌트
+ * - 인증된 사용자: 역할에 맞는 대시보드로 이동
+ * - 비인증 사용자: 로그인 페이지로 이동
+ */
+function HomeRedirect() {
+  const { isAuthenticated, customerRole } = useAuth((state) => ({
+    isAuthenticated: state.isAuthenticated,
+    customerRole: state.customerRole,
+  }))
+
+  if (isAuthenticated) {
+    if (customerRole === 'SENIOR') {
+      return <Navigate to={ROUTE_PATHS.seniorDashboard} replace />
+    }
+    if (customerRole === 'CAREGIVER') {
+      return <Navigate to={ROUTE_PATHS.caregiverDashboard} replace />
+    }
+    // 역할이 선택되지 않은 경우 역할 선택 페이지로 (혹은 기본 대시보드)
+    return <Navigate to={ROUTE_PATHS.roleSelection} replace />
+  }
+
+  return <Navigate to={ROUTE_PATHS.login} replace />
 }
 
 /**
@@ -284,8 +310,8 @@ function App() {
 
             <Route path="/ws-test" element={<WsTestPage />} />
 
-            {/* 기본 경로: 로그인 페이지로 리다이렉트 */}
-            <Route path={ROUTE_PATHS.root} element={<Navigate to={ROUTE_PATHS.login} replace />} />
+            {/* 기본 경로: 인증 상태에 따라 대시보드 또는 로그인 페이지로 리다이렉트 */}
+            <Route path={ROUTE_PATHS.root} element={<HomeRedirect />} />
 
             {/* 404: 존재하지 않는 경로 */}
             <Route path="*" element={<Navigate to={ROUTE_PATHS.login} replace />} />

--- a/src/features/family/components/InviteMemberForm.jsx
+++ b/src/features/family/components/InviteMemberForm.jsx
@@ -58,11 +58,12 @@ export const InviteMemberForm = ({ onSubmit, loading }) => {
       </label>
 
       <label className={styles.label}>
-        이메일<span className={styles.optional}>(선택)</span>
+        이메일
         <input
           type="email"
           placeholder="senior@example.com"
           {...register('email', {
+            required: '이메일을 입력해주세요.',
             pattern: {
               value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
               message: '유효한 이메일을 입력해주세요.',
@@ -71,7 +72,6 @@ export const InviteMemberForm = ({ onSubmit, loading }) => {
           disabled={loading}
         />
         {errors.email && <span className={styles.fieldError}>{errors.email.message}</span>}
-        <span className={styles.hint}>이메일이 없어도 초대 코드를 통해 참여할 수 있습니다.</span>
       </label>
 
       <Controller

--- a/src/features/family/pages/FamilyInvite.module.scss
+++ b/src/features/family/pages/FamilyInvite.module.scss
@@ -78,42 +78,58 @@
 }
 
 .inviteList li {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 12px;
-  padding: 10px 12px;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
-  background: #fff;
+  display: flex; /* Changed from grid to flex */
+  justify-content: space-between;
   align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: #bfdbfe;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  }
 }
 
 .inviteMeta {
-  display: grid;
-  grid-template-columns: auto auto auto;
-  gap: 8px;
+  display: flex;
+  flex-direction: column; /* Stack info vertically */
+  gap: 4px;
   font-size: 13px;
-  align-items: center;
-  grid-column: 1 / -1;
+  flex: 1; /* Take up remaining space */
 }
 
-.email {
-  font-weight: 600;
+/* Optional: Group Name & Role on one line if desired, but simple stack is safe */
+.name {
+  font-weight: 700;
+  font-size: 14px;
   color: #111827;
 }
 
+.email {
+  color: #4b5563;
+  font-size: 13px;
+}
+
 .role {
+  display: inline-block;
   color: #2563eb;
   font-weight: 600;
+  font-size: 12px;
+  margin-top: 2px;
 }
 
 .expiry {
-  color: #6b7280;
-  font-size: 12px;
+  color: #9ca3af;
+  font-size: 11px;
 }
 
 .status {
-  font-size: 12px;
+  font-size: 11px;
+  font-weight: 500;
   color: #f97316;
 }
 
@@ -123,21 +139,31 @@
 
 .inviteList button {
   border: 1px solid #d1d5db;
-  background: #f3f4f6;
-  padding: 8px 12px;
-  border-radius: 10px;
+  background: #fff;
+  color: #374151;
+  padding: 8px 14px;
+  border-radius: 8px;
   cursor: pointer;
-  height: fit-content;
-}
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: all 0.2s;
 
-.inviteList button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+  &:hover {
+    background: #f3f4f6;
+    border-color: #9ca3af;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: wait;
+  }
 }
 
 .inviteActions {
   display: flex;
   gap: 8px;
+  align-items: center;
 }
 
 .shortCodeSection {

--- a/src/shared/components/layout/BottomNavigation.jsx
+++ b/src/shared/components/layout/BottomNavigation.jsx
@@ -31,13 +31,7 @@ const NAV_ITEMS = [
     path: ROUTE_PATHS.medication,
     roles: [ROLE_ALL],
   },
-  {
-    id: 'invite-code',
-    label: '초대코드',
-    icon: 'ticket',
-    path: ROUTE_PATHS.inviteCodeEntry,
-    roles: [ROLE_ALL], // 노인, 보호자 모두 접근 가능
-  },
+
   {
     id: 'family',
     label: '가족',

--- a/src/shared/components/layout/Header.jsx
+++ b/src/shared/components/layout/Header.jsx
@@ -38,14 +38,26 @@ export const Header = () => {
     <header className={styles.header}>
       <div className={styles.headerContainer}>
         {/* 좌측: 로고 및 앱 이름 */}
-        <div className={styles.logoSection}>
+        <div 
+          className={styles.logoSection} 
+          onClick={() => navigate(ROUTE_PATHS.root)}
+          style={{ cursor: 'pointer' }}
+          role="button"
+          tabIndex={0}
+        >
           <div className={styles.logoIcon}>💊</div>
           <span className={styles.appName}>뭐냑? (AMA...Pill)</span>
         </div>
 
         {/* 우측: 사용자 정보 및 알림 */}
         <div className={styles.rightSection}>
-          <div className={styles.userInfo}>
+          <div 
+            className={styles.userInfo}
+            onClick={() => navigate(ROUTE_PATHS.settingsProfile)}
+            style={{ cursor: 'pointer' }}
+            role="button"
+            tabIndex={0}
+          >
             <span className={styles.userName}>{userName} 님</span>
             <span className={styles.userRole}>({roleLabel})</span>
           </div>


### PR DESCRIPTION
## ✨ PR 요약
가족 초대 페이지의 사용자 경험(UX)을 개선하기 위해 레이아웃 깨짐 현상을 수정하고, 불필요한 UI 요소(별표, 중복 버튼)를 제거했습니다. 또한 안내 문구를 부드럽게 수정하여 사용성을 높였습니다.
## 🔗 관련 이슈
Closes #87
## 🛠️ 변경 내용
- **레이아웃 수정**: '보낸 초대' 목록이 화면 너비에 따라 깨지지 않도록 Flexbox Column 구조로 변경했습니다.
- **UI/UX 개선**:
  - 이메일 입력창의 필수 표시(*) 제거.
  - '새로 만들기' 버튼 제거 및 '닫기' 버튼 추가.
  - 초대 안내 문구를 사용자 친화적으로 수정.
- **버그 수정**: 초대 취소/수락 기능이 정상 작동하도록 핸들러 함수 복구.
## ✅ 체크리스트
- [x] 코드가 스타일 가이드라인을 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [ ] 주석을 추가했습니다 (특히 복잡한 로직).
- [x] 관련 이슈를 링크했습니다.
- [x] 커밋 메시지가 명확합니다.
## 🙋 리뷰어에게
