### PR TITLE
🐛 Fix: Prevent duplicate medication & schedule logic (#96)

### DIFF
--- a/src/features/medication/components/MedicationForm.jsx
+++ b/src/features/medication/components/MedicationForm.jsx
@@ -78,6 +78,28 @@ export const MedicationForm = ({
 
   const handleSubmit = async (event) => {
     event.preventDefault()
+
+    // 클라이언트 사이드 스케줄 중복 검증
+    if (form.schedules && form.schedules.length > 0) {
+      const timeMap = {} // time -> Set<day>
+      for (const schedule of form.schedules) {
+        if (!schedule.time || !schedule.daysOfWeek) continue
+        
+        if (!timeMap[schedule.time]) {
+          timeMap[schedule.time] = new Set()
+        }
+
+        const days = schedule.daysOfWeek.split(',')
+        for (const day of days) {
+          if (timeMap[schedule.time].has(day)) {
+            alert(`중복된 스케줄이 있습니다: ${schedule.time} (${day})`)
+            return
+          }
+          timeMap[schedule.time].add(day)
+        }
+      }
+    }
+
     await onSubmit?.(form)
     if (shouldResetOnSubmit) {
       setForm(initialForm)


### PR DESCRIPTION
# 🐛 Fix: Prescription UX Improvement & Schedule Validation Hardening (#96)

## 🔍 Issue (이슈)
- **#96**

## 📝 Description (설명)
- **약물 스케줄 중복 방지 (Frontend)**: `MedicationForm`에서 동일한 시간/요일 스케줄 입력을 클라이언트 단에서 차단.
- **약물 중복 등록 방지**: 처방전 수동 등록 및 OCR 로드 시 이미 존재하는 약물은 중복 추가되지 않도록 차단.
- **처방전 약물 수정 기능 구현**: 약물 목록에서 '수정' 버튼이 동작하지 않던 문제 해결 (모달을 통해 세부 정보 수정 가능).

## ✅ Verification (검증)
- [x] 스케줄 폼에서 "09:00 월" 중복 입력 시 경고창 발생 확인.
- [x] 처방전 페이지에서 같은 약물 추가 시 "이미 추가된 약입니다" 토스트 메시지 확인.
- [x] 약물 목록의 '수정' 버튼 클릭 시 모달이 열리고 데이터 수정 후 반영되는지 확인.
