### PR TITLE
feat: 음성 명령, 동일 페이지 및 탭 전환 시에도 정상 작동하도록 개선

### DIFF
--- a/src/features/dashboard/components/MyMedicationSchedule.jsx
+++ b/src/features/dashboard/components/MyMedicationSchedule.jsx
@@ -38,6 +38,7 @@ export const MyMedicationSchedule = ({
   className = ''
 }) => {
   const navigate = useNavigate()
+  const pendingAction = useVoiceActionStore((state) => state.pendingAction) // [Voice] Subscribe
   const { consumeAction } = useVoiceActionStore() // [Voice]
   const { medications, fetchMedications } = useMedicationStore()
   const [medicationLogs, setMedicationLogs] = useState([])
@@ -102,7 +103,7 @@ export const MyMedicationSchedule = ({
 
   // [Voice] 음성 명령 처리 (자동 복용 체크)
   useEffect(() => {
-    if (!loading && todaySchedules.length > 0) {
+    if (!loading && todaySchedules.length > 0 && pendingAction?.code === 'AUTO_COMPLETE') {
       const action = consumeAction('AUTO_COMPLETE')
       
       if (action) {
@@ -143,7 +144,7 @@ export const MyMedicationSchedule = ({
         }
       }
     }
-  }, [loading, todaySchedules, consumeAction])
+  }, [loading, todaySchedules, consumeAction, pendingAction])
 
   const handleTakeMedication = async (scheduleId) => {
     const [medicationId, schedId] = scheduleId.split('-')

--- a/src/features/diet/pages/DietLogPage.jsx
+++ b/src/features/diet/pages/DietLogPage.jsx
@@ -19,13 +19,12 @@ export const DietLogPage = () => {
 
   // Voice Action State
   const [autoFillData, setAutoFillData] = useState(null)
-  const { consumeAction, getPendingAction } = useVoiceActionStore()
+  const pendingAction = useVoiceActionStore((state) => state.pendingAction) // [Voice] Subscribe
+  const { consumeAction } = useVoiceActionStore()
 
   // Voice Command Handling (Auto Fill)
   useEffect(() => {
-    const pending = getPendingAction()
-    
-    if (pending && pending.code === 'AUTO_LOG_DIET') {
+    if (pendingAction && pendingAction.code === 'AUTO_LOG_DIET') {
       const action = consumeAction('AUTO_LOG_DIET')
       if (action && action.params) {
         logger.info('🎤 Voice Action Auto-Fill:', action)
@@ -35,7 +34,7 @@ export const DietLogPage = () => {
         })
       }
     }
-  }, [consumeAction, getPendingAction])
+  }, [pendingAction, consumeAction])
 
   const fetchMeals = useCallback(async () => {
     setLoading(true)

--- a/src/features/medication/pages/TodayMedications.jsx
+++ b/src/features/medication/pages/TodayMedications.jsx
@@ -10,6 +10,7 @@ import { ko } from 'date-fns/locale';
 import logger from '@core/utils/logger';
 
 const TodayMedications = () => {
+    const pendingAction = useVoiceActionStore((state) => state.pendingAction); // [Voice] Subscribe
     const { consumeAction } = useVoiceActionStore(); // [Voice]
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
@@ -42,7 +43,7 @@ const TodayMedications = () => {
 
     // [Voice] 음성 명령 처리 (자동 복용 체크) - Zustand 버전
     useEffect(() => {
-        if (!loading && logs.length > 0) {
+        if (!loading && logs.length > 0 && pendingAction?.code === 'AUTO_COMPLETE') {
             // 스토어에서 'AUTO_COMPLETE' 명령이 있는지 확인하고 가져옴 (가져오면 스토어에선 삭제됨)
             const action = consumeAction('AUTO_COMPLETE');
             
@@ -94,7 +95,7 @@ const TodayMedications = () => {
                 }
             }
         }
-    }, [loading, logs, consumeAction]); // consumeAction이 의존성에 포함됨
+    }, [loading, logs, consumeAction, pendingAction]); // consumeAction이 의존성에 포함됨
 
     const handleMedicationClick = (medication) => {
         // TODO: Implement medication detail view

--- a/src/features/search/components/PillSearchTab.jsx
+++ b/src/features/search/components/PillSearchTab.jsx
@@ -36,7 +36,8 @@ const summarize = (text = '', limit = 140) => {
 export const PillSearchTab = () => {
   const navigate = useNavigate()
   const location = useLocation()
-  const { consumeAction, getPendingAction } = useVoiceActionStore() // [Voice]
+  const pendingAction = useVoiceActionStore((state) => state.pendingAction) // [Voice] Subscribe to state
+  const { consumeAction } = useVoiceActionStore()
   const [itemName, setItemName] = useState('')
   const [results, setResults] = useState([])
   const [loading, setLoading] = useState(false)
@@ -138,14 +139,11 @@ export const PillSearchTab = () => {
 
   // [Voice] 자동 검색 (Zustand)
   useEffect(() => {
-    // 1. 대기 중인 액션 확인 (삭제하지 않고 조회만)
-    const pending = getPendingAction()
-    
-    // 2. 내 타입('PILL')이거나 타입이 없을 때만 실행
-    if (pending && pending.code === 'AUTO_SEARCH') {
-        const type = pending.params?.searchType
+    // 1. 대기 중인 액션 확인 (Reactive)
+    if (pendingAction && pendingAction.code === 'AUTO_SEARCH') {
+        const type = pendingAction.params?.searchType
         if (!type || type === 'PILL') {
-            // 3. 내 것이 확실하므로 소비(삭제)하고 실행
+            // 2. 내 것이 확실하므로 소비(삭제)하고 실행
             const action = consumeAction('AUTO_SEARCH')
             if (action && action.params?.query) {
                 const keyword = action.params.query
@@ -154,7 +152,7 @@ export const PillSearchTab = () => {
             }
         }
     }
-  }, [getPendingAction, consumeAction, executeSearch])
+  }, [pendingAction, consumeAction, executeSearch])
 
   // 자동 검색 (location.state.autoSearch 감지)
   useEffect(() => {

--- a/src/features/search/components/SymptomSearchTab.jsx
+++ b/src/features/search/components/SymptomSearchTab.jsx
@@ -7,7 +7,8 @@ import { AiWarningModal } from '@shared/components/ui/AiWarningModal'
 import logger from '@core/utils/logger'
 
 export const SymptomSearchTab = () => {
-  const { consumeAction, getPendingAction } = useVoiceActionStore() // [Voice]
+  const pendingAction = useVoiceActionStore((state) => state.pendingAction) // [Voice] Subscribe
+  const { consumeAction } = useVoiceActionStore()
   const [query, setQuery] = useState('')
   const [results] = useState([])
   const [selectedSymptom, setSelectedSymptom] = useState(null)
@@ -112,12 +113,10 @@ export const SymptomSearchTab = () => {
   // [Voice] 음성 명령 처리 로직 (반드시 함수 정의 아래에 배치)
   // ==========================================
 
-  // 1. 자동 검색 트리거 (Zustand)
+  // 1. 자동 검색 트리거 (Zustand Reactive)
   useEffect(() => {
-    const pending = getPendingAction()
-    
-    if (pending && pending.code === 'AUTO_SEARCH') {
-        const type = pending.params?.searchType
+    if (pendingAction && pendingAction.code === 'AUTO_SEARCH') {
+        const type = pendingAction.params?.searchType
         // 'SYMPTOM' 타입일 때만 실행
         if (type === 'SYMPTOM') {
             const action = consumeAction('AUTO_SEARCH')
@@ -128,7 +127,7 @@ export const SymptomSearchTab = () => {
             }
         }
     }
-  }, [getPendingAction, consumeAction])
+  }, [pendingAction, consumeAction])
 
   // 2. 트리거가 당겨지면 handleAiSearch 실행
   useEffect(() => {

--- a/src/features/search/pages/UnifiedSearchPage.jsx
+++ b/src/features/search/pages/UnifiedSearchPage.jsx
@@ -17,21 +17,20 @@ import styles from './UnifiedSearchPage.module.scss'
  * @returns {JSX.Element}
  */
 export const UnifiedSearchPage = () => {
-  const { getPendingAction } = useVoiceActionStore() // [Voice]
+  const pendingAction = useVoiceActionStore((state) => state.pendingAction) // [Voice] Subscribe
   const [initialTab, setInitialTab] = useState('symptom')
 
   useEffect(() => {
-    // 페이지 진입 시 대기 중인 액션 확인하여 탭 결정
-    const action = getPendingAction()
-    if (action && action.code === 'AUTO_SEARCH') {
-      const type = action.params?.searchType // 'PILL' or 'SYMPTOM'
+    // 실시간으로 대기 중인 액션 감지하여 탭 전환
+    if (pendingAction && pendingAction.code === 'AUTO_SEARCH') {
+      const type = pendingAction.params?.searchType // 'PILL' or 'SYMPTOM'
       if (type === 'PILL') {
         setInitialTab('pill')
       } else if (type === 'SYMPTOM') {
         setInitialTab('symptom')
       }
     }
-  }, [getPendingAction])
+  }, [pendingAction])
 
   const tabs = [
     {


### PR DESCRIPTION
 - 각 음성 명령 처리 컴포넌트(PillSearchTab, SymptomSearchTab, DietLogPage, TodayMedications, MyMedicationSchedule)에서 useVoiceActionStore의 pendingAction 상태를 직접 구독하도록 변경.
   - useEffect의 의존성 배열에 pendingAction을 추가하여, pendingAction 상태 변화 시 명령 처리 로직이 즉시 실행되도록 수정.
   - UnifiedSearchPage에서 음성 명령(AUTO_SEARCH)의 searchType(PILL 또는 SYMPTOM)에 따라 검색 탭이 자동으로 전환되도록 로직 추가.

## ✨ PR 요약
<!-- PR의 목적을 간략히 설명해주세요 -->


## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
Closes #
Related to #


## 🛠️ 변경 내용
<!-- 변경 사항을 구체적으로 설명해주세요 -->


## ✅ 체크리스트
<!-- PR 제출 시 확인해주세요! -->
- [ ] 코드가 스타일 가이드라인을 따릅니다.
- [ ] 자체 코드 리뷰를 완료했습니다.
- [ ] 주석을 추가했습니다 (특히 복잡한 로직).
- [ ] 관련 이슈를 링크했습니다.
- [ ] 커밋 메시지가 명확합니다.


## 🙋 리뷰어에게
<!-- 리뷰어가 특별히 확인해주길 원하는 부분이나 고민했던 점을 작성해주세요 -->