### PR TITLE
🚑 Hotfix: Cleanup mock data, fix 500 error handling, and adjust UI la…

### DIFF
--- a/src/constants/uiConstants.js
+++ b/src/constants/uiConstants.js
@@ -27,7 +27,7 @@ export const CAREGIVER_QUICK_ACTIONS = [
   { icon: '👥', label: '가족 관리', path: ROUTE_PATHS.family },
   { icon: '💊', label: '약 관리', path: ROUTE_PATHS.medication },
   { icon: '🔍', label: '검색', path: ROUTE_PATHS.search },
-  { icon: '💬', label: '상담', path: ROUTE_PATHS.chatList },
+  { icon: '📊', label: '리포트', path: ROUTE_PATHS.adherenceReport },
 ]
 
 // 보호자 대시보드 FAB 액션

--- a/src/core/services/api/medicationApiClient.js
+++ b/src/core/services/api/medicationApiClient.js
@@ -17,19 +17,7 @@ class MedicationApiClient extends ApiClient {
    * @returns {Promise<Object>} 오늘의 스케줄 정보
    */
   getTodayMedications() {
-    return this.get('/today', undefined, {
-      mockResponse: () => ({
-        schedules: [
-          {
-            id: 1,
-            medicationName: '타이레놀',
-            scheduledTime: '13:00',
-            isTaken: false,
-            status: 'PENDING'
-          }
-        ]
-      })
-    })
+    return this.get('/today')
   }
 
   create(payload) {

--- a/src/features/chat/pages/ChatConversationPage.jsx
+++ b/src/features/chat/pages/ChatConversationPage.jsx
@@ -47,8 +47,8 @@ export const ChatConversationPage = () => {
       if (counselorMessage) {
         setCounselor({
           id: counselorMessage.senderId,
-          name: '김의사', // TODO: 실제 API에서 가져오기
-          profileImage: 'https://via.placeholder.com/100',
+          name: counselorMessage.senderName || '상담사',
+          profileImage: counselorMessage.senderProfileImage,
           type: 'doctor',
         })
       }
@@ -162,10 +162,7 @@ export const ChatConversationPage = () => {
         {/* 입력창 */}
         <ChatInput onSend={handleSendMessage} disabled={isSending} />
 
-        {/* WebSocket 미연동 알림 */}
-        <div className={styles.notice}>
-          <p>⚠️ WebSocket 연동 전: 실시간 메시지는 Mock 데이터로 표시됩니다.</p>
-        </div>
+
       </div>
     </MainLayout>
   )

--- a/src/features/chat/pages/DoctorChatListPage.jsx
+++ b/src/features/chat/pages/DoctorChatListPage.jsx
@@ -33,15 +33,8 @@ export const DoctorChatListPage = () => {
   }
 
   const handleCreateNewChat = async () => {
-    try {
-      // TODO: 의사/AI 챗봇 선택 모달 구현 필요
-      // 지금은 임시로 새 채팅방 생성
-      const newRoom = await chatApiClient.createRoom('doctor_ai_001')
-      setRooms([newRoom, ...rooms])
-    } catch (err) {
-      logger.error('채팅방 생성 실패:', err)
-      alert('채팅방 생성에 실패했습니다.')
-    }
+    // TODO: 의사/AI 챗봇 선택 모달 구현 후 연동
+    alert('준비 중인 기능입니다.')
   }
 
   return (
@@ -84,12 +77,6 @@ export const DoctorChatListPage = () => {
             ))}
           </div>
         )}
-
-        <div className={styles.notice}>
-          <p>💡 <strong>Stage 4 Preview</strong></p>
-          <p>실시간 채팅은 WebSocket 연동 후 활성화됩니다.</p>
-          <p>의사 상담 및 AI 챗봇 기능은 추후 구현 예정입니다.</p>
-        </div>
       </div>
     </MainLayout>
   )

--- a/src/features/counsel/pages/DoctorCounsel.jsx
+++ b/src/features/counsel/pages/DoctorCounsel.jsx
@@ -19,7 +19,7 @@ export const DoctorCounselPage = () => {
       <div className={styles.page}>
         <header className={styles.header}>
           <h1>의사 상담</h1>
-          <p>궁금한 내용을 작성해 상담을 요청해 보세요 (모의)</p>
+          <p>궁금한 내용을 작성해 상담을 요청해 보세요</p>
         </header>
 
         <section className={styles.panel}>
@@ -37,13 +37,9 @@ export const DoctorCounselPage = () => {
 
           <div className={styles.actions}>
             <button type="button" className={styles.button} onClick={handleSubmit}>
-              상담 요청 (Mock)
+              상담 요청
             </button>
           </div>
-
-          <p className={styles.hint}>
-            실제 상담 기능은 Stage 4 이후 연동 예정입니다.
-          </p>
         </section>
       </div>
     </MainLayout>

--- a/src/features/dashboard/components/MyMedicationSchedule.jsx
+++ b/src/features/dashboard/components/MyMedicationSchedule.jsx
@@ -149,6 +149,12 @@ export const MyMedicationSchedule = ({
   const handleTakeMedication = async (scheduleId) => {
     const [medicationId, schedId] = scheduleId.split('-')
 
+    if (!schedId || schedId === 'undefined' || schedId === 'null' || isNaN(parseInt(schedId))) {
+      logger.error('Invalid schedule ID:', scheduleId)
+      toast.error('유효하지 않은 스케줄입니다.')
+      return
+    }
+
     try {
       // Optimistic update: 즉시 UI 업데이트
       const optimisticLog = {
@@ -168,7 +174,7 @@ export const MyMedicationSchedule = ({
       logger.debug('복용 완료:', scheduleId)
     } catch (error) {
       logger.error('Failed to complete medication:', error)
-      alert('복용 기록 저장에 실패했습니다.')
+      toast.error('복용 기록 저장에 실패했습니다.')
       // 에러 발생 시 다시 로드하여 원래 상태로 복구
       await loadMedicationLogs()
     }

--- a/src/features/voice/components/VoiceAssistant.jsx
+++ b/src/features/voice/components/VoiceAssistant.jsx
@@ -36,7 +36,7 @@ export const VoiceAssistant = () => {
       )}
 
       {/* [DEBUG] 음성 명령 시뮬레이션 입력창 */}
-      <div style={{ position: 'fixed', bottom: '90px', right: '24px', zIndex: 9999, background: 'white', padding: '5px', borderRadius: '8px', boxShadow: '0 2px 10px rgba(0,0,0,0.1)' }}>
+      <div style={{ position: 'fixed', bottom: '150px', left: '20px', zIndex: 9999, background: 'white', padding: '5px', borderRadius: '8px', boxShadow: '0 2px 10px rgba(0,0,0,0.1)' }}>
         <input 
           type="text" 
           value={debugText}

--- a/src/features/voice/components/VoiceAssistant.module.scss
+++ b/src/features/voice/components/VoiceAssistant.module.scss
@@ -1,11 +1,11 @@
 .voiceContainer {
   position: fixed;
   bottom: 80px; /* 하단 네비게이션 위쪽 */
-  right: 20px;
+  left: 20px;
   z-index: 9999;
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start; /* flex-end에서 flex-start로 변경 (좌측 정렬) */
 }
 
 .micButton {


### PR DESCRIPTION
# PR #110: Frontend Cleanup & Senior Dashboard Hotfix

## 🔗 Issue
- #110

## 📝 변경 사항

### Frontend (`hotfix/#110-frontend-cleanup`)
1.  **SeniorDashboard.jsx**:
    *   주간 통계(Weekly Stats) Mock 데이터 제거 및 `getDailyAdherence` API 연동.
    *   `handleToggleTimeSection`: 스케줄 ID가 없는 로그를 필터링하여 500 에러 방지.
    *   `pb: 12` 추가하여 하단 네비게이션 바에 컨텐츠가 가려지는 문제 해결.
2.  **MyMedicationSchedule.jsx**:
    *   `scheduleId` 유효성 검사 강화 및 에러 토스트 처리.
3.  **Chat/Counsel Cleanup**:
    *   `ChatConversationPage.jsx`: 하드코딩된 '김의사' Mock 데이터 제거.
    *   `DoctorChatListPage.jsx`: 하드코딩된 방 생성 로직 제거.
    *   `DoctorCounsel.jsx`: '(Mock)' 라벨 및 개발용 힌트 제거.
    *   `uiConstants.js`: '상담' 메뉴를 '리포트'로 변경하여 미구현 기능 접근 차단.
4.  **VoiceAssistant**:
    *   버튼 및 디버그 입력창 위치를 좌측 하단으로 이동.
5.  **API Clients**:
    *   `medicationApiClient`: Mock Response 제거.
    *   `voiceApiClient`: Mock Response 복구 (요청사항).

### Backend (`hotfix/#110-backend-fix`)
1.  **ResourceNotFoundException.java**:
    *   `RuntimeException` 대신 `BusinessException`을 상속받도록 수정.
    *   이로 인해 리소스 부재 시 500 Internal Server Error 대신 `GlobalExceptionHandler`를 통해 적절한 에러 코드(404 등)가 반환됨.

## 📸 스크린샷
(UI 변경 사항 확인 필요: Senior Dashboard 하단 여백, Voice Assistant 위치)

## 💬 리뷰 포인트
- Senior Dashboard에서 '오늘 복약' 체크 시 500 에러가 더 이상 발생하지 않는지 확인.
- 주간 통계가 실제 데이터로 표시되는지 확인.
- Voice 버튼이 좌측 하단에 정상적으로 표시되는지 확인.
