### PR TITLE
🐛 Fix: Rerender after group dissolve (#115)

### DIFF
--- a/src/features/family/pages/FamilyManagement.jsx
+++ b/src/features/family/pages/FamilyManagement.jsx
@@ -28,9 +28,10 @@ export const FamilyManagementPage = () => {
     createFamilyGroup,
     removeMember,
     updateMemberRole,
+    deleteGroup,
     loading,
     error,
-    fetchFamily: refetchFamily
+    refetchFamily,
   } = useFamilyStore()
   const [currentUserRole, setCurrentUserRole] = useState(null)
   const onlineMemberIds = []
@@ -323,9 +324,8 @@ export const FamilyManagementPage = () => {
                   } else if (confirmModal.type === 'dissolve') {
                     setDissolving(true)
                     try {
-                      await familyApiClient.deleteGroup(familyGroup.id)
+                      await deleteGroup(familyGroup.id)
                       toast.success('그룹이 해산되었습니다.')
-                      await refetchFamily?.()
                     } catch (error) {
                       toast.error('그룹 해산에 실패했습니다. 다시 시도해 주세요.')
                       logger.warn('[FamilyManagement] dissolve failed', error)


### PR DESCRIPTION
# PR: Family 초대 역할 수정 500 + 그룹 해산 리렌더링 버그 수정

## 관련 이슈

- Frontend #116 (그룹 해산 후 리렌더링 불가)
close #116
## 요약

- 초대 역할 수정 시 발생하던 500(서버 에러) 원인을 제거하고, 올바른 상태코드(400/403/410)로 응답하도록 보강했습니다.
- 그룹 해산 후 UI가 즉시 갱신되지 않던 문제를 Store 상태 업데이트로 해결했습니다.

## 배경 / 문제

1) 프론트에서 초대 역할 수정 시 아래 요청이 500으로 실패

- `PUT /api/family/invites/{inviteId}`

2) 그룹 해산 후 토스트는 뜨지만, 화면이 이전 그룹 상태로 남아 리렌더링이 되지 않음

## 변경 사항

### Backend (spring-boot)

- `PUT /family/invites/{inviteId}` 엔드포인트 추가 (suggestedRole 변경, 204 반환)
- 초대 생성 응답에 `InviteResponse.id` 포함 (프론트가 shortCode를 ID로 오용하지 않도록)
- MyBatis update 쿼리에 `suggested_role` 업데이트 추가
- 예외 처리 보강
  - 생성자가 아닌 사용자가 수정 시 403 반환 (`UnauthorizedException` 핸들링)
  - `inviteId` 타입 변환 실패 시 400 반환 (`MethodArgumentTypeMismatchException` 핸들링)

### Front (Front)

- 그룹 해산 시 Store 상태를 즉시 업데이트하여 UI 리렌더링 보장
- 삭제된 그룹이 선택된 상태로 남는 케이스를 방지하도록 `loadFamily()` 선택 그룹 검증 추가

### Docs

- `docs/shadow/api_list.md`에 `PUT /invites/{inviteId}` 명세 반영

## 변경 파일

### Backend

- `spring-boot/src/main/java/com/amapill/backend/domain/family/application/dto/request/UpdateInviteRequest.java`
- `spring-boot/src/main/java/com/amapill/backend/domain/family/application/service/IInvitationService.java`
- `spring-boot/src/main/java/com/amapill/backend/domain/family/application/service/InvitationService.java`
- `spring-boot/src/main/java/com/amapill/backend/domain/family/api/FamilyInviteController.java`
- `spring-boot/src/main/java/com/amapill/backend/domain/family/application/dto/response/InviteResponse.java`
- `spring-boot/src/main/resources/mappers/family/FamilyInviteMapper.xml`
- `spring-boot/src/main/java/com/amapill/backend/global/exception/GlobalExceptionHandler.java`

### Front

- `Front/src/features/family/store/familyStore.js`
- `Front/src/features/family/pages/FamilyManagement.jsx`

### Docs

- `docs/shadow/api_list.md`
- `docs/issues/family_bugfix_2025-12-13.md`

## 테스트 / 검증

- Backend 빌드: `spring-boot`에서 `./gradlew clean build -x test` 성공
- 수동 확인(권장)
  - 초대 생성 응답에 `id` 필드 포함 확인
  - `PUT /api/family/invites/{inviteId}` 정상 수정(204)
  - 본인이 생성하지 않은 inviteId 수정 시 403
  - 만료된 inviteId 수정 시 410
  - `PUT /api/family/invites/54KEWW` 같이 문자열로 호출 시 400
  - 그룹 해산 후 UI가 즉시 빈 상태/다른 그룹으로 전환되는지 확인


