### PR TITLE
🐛 Fix: 음식 인식 실패 시 등록 버튼 비활성화 (#118)

### DIFF
--- a/src/features/diet/components/DietAnalysisModal.jsx
+++ b/src/features/diet/components/DietAnalysisModal.jsx
@@ -173,20 +173,33 @@ const DietAnalysisModal = ({ isOpen, onClose, analysisResult, onSave, isLoading,
                 )}
             </DialogContent>
 
-            <DialogActions sx={{ p: 2 }}>
-                <Button onClick={onClose} color="inherit">
-                    취소
-                </Button>
-                {editedResult && (
-                    <Button
-                        onClick={handleSave}
-                        variant="contained"
-                        startIcon={<CheckIcon />}
-                        sx={{ borderRadius: 2 }}
+            <DialogActions sx={{ p: 2, flexDirection: 'column', gap: 1 }}>
+                {/* Warning message when isFood is false */}
+                {editedResult && editedResult.isFood === false && (
+                    <Typography
+                        variant="body2"
+                        color="error"
+                        sx={{ width: '100%', textAlign: 'center', mb: 1 }}
                     >
-                        확인 및 저장
-                    </Button>
+                        ⚠️ 음식으로 인식되지 않아 등록할 수 없습니다.
+                    </Typography>
                 )}
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%', gap: 1 }}>
+                    <Button onClick={onClose} color="inherit">
+                        취소
+                    </Button>
+                    {editedResult && (
+                        <Button
+                            onClick={handleSave}
+                            variant="contained"
+                            startIcon={<CheckIcon />}
+                            sx={{ borderRadius: 2 }}
+                            disabled={editedResult.isFood === false || editedResult.foodName === '알 수 없음'}
+                        >
+                            확인 및 저장
+                        </Button>
+                    )}
+                </Box>
             </DialogActions>
         </Dialog>
     );

--- a/src/features/diet/components/MealInputForm.jsx
+++ b/src/features/diet/components/MealInputForm.jsx
@@ -131,10 +131,18 @@ export const MealInputForm = ({
     }
   }
 
+  // Check if food is recognized
+  const isNotFood = analysisResult?.isFood === false || foodName === '알 수 없음'
+
   const handleSubmit = (e) => {
     e.preventDefault()
     if (!foodName.trim()) {
       alert('음식 이름을 입력해주세요.')
+      return
+    }
+    // Prevent submission if not recognized as food
+    if (isNotFood) {
+      alert('음식으로 인식되지 않아 등록할 수 없습니다.')
       return
     }
     const mealData = {
@@ -313,12 +321,20 @@ export const MealInputForm = ({
               </Button>
             )}
 
+            {/* Warning when isFood is false */}
+            {isNotFood && (
+              <Typography variant="body2" color="error" sx={{ width: '100%', textAlign: 'center' }}>
+                ⚠️ 음식으로 인식되지 않아 등록할 수 없습니다.
+              </Typography>
+            )}
+
             <Button
               type="submit"
               variant="contained"
               color="primary"
               fullWidth
               size="large"
+              disabled={isNotFood}
               sx={{ borderRadius: 3, py: 1.5, boxShadow: 2 }}
             >
               {isEditing ? '식단 수정 완료' : '식단 추가하기'}


### PR DESCRIPTION
# 🐛 Issue #118: 음식이 아닌 이미지 등록 버튼 비활성화 (Frontend)

## 버그 설명
AI가 이미지를 음식으로 인식하지 못했을 때(`isFood: false`), 프론트엔드에서 "식단 추가하기" 버튼이 여전히 활성화되어 있어 사용자가 등록을 시도할 수 있음.

## 재현 방법
1. 식단 기록 페이지 이동
2. 음식이 아닌 이미지 업로드 (예: 사람 얼굴 사진)
3. AI 분석 완료 후 "알 수 없음"으로 표시
4. ❌ **기존**: "식단 추가하기" 버튼이 활성화 상태 → 버그

## 예상 동작
- `isFood: false`일 때 "식단 추가하기" 버튼이 비활성화되어야 함
- 사용자에게 "음식으로 인식되지 않아 등록할 수 없습니다" 메시지 표시

## 실제 동작 (수정 전)
- 버튼이 활성화되어 있어 클릭 가능
- 클릭 시 백엔드에서 400 에러 반환 (불필요한 API 호출)

## 심각도
⚠️ Medium - UX 개선 필요

---

# ✨ PR #118: 음식 인식 실패 시 UI 비활성화 (Frontend)

## PR 요약
AI가 이미지를 음식으로 인식하지 못한 경우, 프론트엔드에서 등록 버튼을 비활성화하고 경고 메시지를 표시하는 UX 개선.

## 🔗 관련 이슈
Closes #118
Related to #104 (Backend 음식 인식 검증)

## 🛠️ 변경 내용

### 1. `MealInputForm.jsx`
- `isNotFood` 상태 변수 추가: `isFood === false` 또는 `foodName === '알 수 없음'` 체크
- 경고 메시지 UI 추가
- "식단 추가하기" 버튼 `disabled` 속성 추가
- `handleSubmit()`에서 추가 검증

```jsx
// Check if food is recognized
const isNotFood = analysisResult?.isFood === false || foodName === '알 수 없음'

// Warning message
{isNotFood && (
  <Typography variant="body2" color="error">
    ⚠️ 음식으로 인식되지 않아 등록할 수 없습니다.
  </Typography>
)}

// Disabled button
<Button
  type="submit"
  disabled={isNotFood}
  ...
>
  식단 추가하기
</Button>
```

### 2. `DietAnalysisModal.jsx`
- 분석 결과 모달에서도 동일한 검증 로직 추가
- "확인 및 저장" 버튼 비활성화
- 경고 메시지 표시

```jsx
{editedResult && editedResult.isFood === false && (
  <Typography variant="body2" color="error">
    ⚠️ 음식으로 인식되지 않아 등록할 수 없습니다.
  </Typography>
)}

<Button
  disabled={editedResult.isFood === false || editedResult.foodName === '알 수 없음'}
  ...
>
  확인 및 저장
</Button>
```

## 📸 변경 전/후

### 변경 전
- 음식 아닌 이미지 업로드 시 버튼 활성화
- 클릭 시 백엔드 에러 발생

### 변경 후
- 버튼 비활성화 (회색 처리)
- 명확한 경고 메시지 표시
- 불필요한 API 호출 방지

## ✅ 체크리스트
- [x] 코드가 스타일 가이드라인을 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 주석을 추가했습니다 (특히 복잡한 로직).
- [x] 관련 이슈를 링크했습니다.
- [x] 커밋 메시지가 명확합니다.

## 🙋 리뷰어에게
- **UX 개선**: 불필요한 API 호출을 프론트에서 차단
- **일관성**: `MealInputForm`과 `DietAnalysisModal` 두 곳 모두 수정
- **백엔드 연동**: Backend #104와 함께 작동하여 이중 검증 구현
