### PR TITLE
feat(settings): 프로필 수정 기능 구현 (이미지 및 정보 업데이트)

### DIFF
--- a/src/core/services/api/userApiClient.js
+++ b/src/core/services/api/userApiClient.js
@@ -1,0 +1,36 @@
+import ApiClient from './ApiClient'
+import envConfig from '@config/environment.config'
+
+class UserApiClient extends ApiClient {
+  constructor() {
+    super({
+      baseURL: envConfig.AUTH_API_URL,
+      basePath: '/api/auth/users',
+    })
+  }
+
+  getMe() {
+    return this.get('/me')
+  }
+
+  updateMe(data) {
+    return this.put('/me', data)
+  }
+
+  uploadProfileImage(file) {
+    const formData = new FormData()
+    formData.append('file', file)
+    return this.post('/me/image', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+  }
+
+  deleteMe() {
+    return this.delete('/me')
+  }
+}
+
+export const userApiClient = new UserApiClient()
+export { UserApiClient }

--- a/src/features/auth/store/authStore.js
+++ b/src/features/auth/store/authStore.js
@@ -9,6 +9,7 @@ import logger from '@core/utils/logger'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { authApiClient } from '@core/services/api/authApiClient'
+import { userApiClient } from '@core/services/api/userApiClient'
 import { STORAGE_KEYS } from '@config/constants'
 
 const initialState = {
@@ -183,6 +184,41 @@ export const useAuthStore = create(
 
       // Alias for selectRole (체크리스트 호환성)
       updateUserRole: async (selectedRole) => get().selectRole(selectedRole),
+
+      updateUser: async (data) =>
+        withLoading(set, async () => {
+          let updatedUser = null
+
+          // 1. 이미지가 있으면 먼저 업로드 (이미지 변경)
+          if (data.profileImageFile) {
+            const imageResponse = await userApiClient.uploadProfileImage(data.profileImageFile)
+            // imageResponse가 user 객체를 반환한다고 가정 (백엔드 로직에 따름)
+            updatedUser = imageResponse 
+          }
+
+          // 2. 텍스트 정보 업데이트 (이름, 전화번호 등)
+          // 이미지만 바꾼 경우 텍스트 업데이트 생략 가능하지만, 
+          // 안전하게 텍스트 정보도 같이 보냄 (또는 data에서 file 제외하고 보냄)
+          const { profileImageFile, ...textData } = data
+          
+          // 텍스트 데이터가 변경된 게 있으면 호출
+          if (Object.keys(textData).length > 0) {
+             updatedUser = await userApiClient.updateMe(textData)
+          }
+
+          // 기존 토큰 등은 유지하고 user 정보만 업데이트
+          const currentUser = get().user
+          // updatedUser가 없으면(둘 다 실행 안됨?) 기존 유지
+          const finalUser = updatedUser || currentUser
+          
+          const newUserState = { ...currentUser, ...finalUser }
+          
+          get().setAuthData({
+            ...get(), // 기존 토큰 및 상태 유지
+            user: newUserState
+          })
+          return newUserState
+        }),
 
       logout: async () => {
         set({ loading: true, error: null })

--- a/src/features/settings/components/ProfileSection.jsx
+++ b/src/features/settings/components/ProfileSection.jsx
@@ -1,0 +1,132 @@
+import { useState } from 'react'
+import { useAuth } from '@features/auth/hooks/useAuth'
+import styles from './ProfileSection.module.scss'
+
+export const ProfileSection = ({ user }) => {
+  const { updateUser } = useAuth((state) => ({ updateUser: state.updateUser }))
+  const [isEditing, setIsEditing] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [formData, setFormData] = useState({
+    name: '',
+    phone: '',
+  })
+
+  // 초기화 및 편집 모드 진입
+  const handleEditClick = () => {
+    setFormData({
+      name: user?.name || '',
+      phone: user?.phone || '',
+    })
+    setIsEditing(true)
+  }
+
+  const handleCancel = () => {
+    setIsEditing(false)
+  }
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSave = async () => {
+    if (!formData.name.trim()) return
+
+    try {
+      setIsLoading(true)
+      await updateUser({
+        name: formData.name,
+        phone: formData.phone,
+        // profileImage는 추후 파일 업로드 구현 시 추가
+      })
+      setIsEditing(false)
+    } catch (error) {
+      console.error('Failed to update profile:', error)
+      alert('프로필 수정에 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (!user) {
+    return (
+      <section className={styles.profileSection}>
+        <div className={styles.avatarPlaceholder}>?</div>
+        <div>
+          <p className={styles.name}>게스트</p>
+          <p className={styles.email}>로그인이 필요합니다</p>
+        </div>
+      </section>
+    )
+  }
+
+  const initials = user.name?.[0] ?? 'U'
+
+  return (
+    <section className={styles.profileSection}>
+      <div className={styles.avatar}>
+        {user.profileImage ? (
+          <img src={user.profileImage} alt="Profile" className={styles.avatarImage} />
+        ) : (
+          initials
+        )}
+      </div>
+
+      {isEditing ? (
+        <div className={styles.editForm}>
+          <div className={styles.inputGroup}>
+            <label className={styles.label}>닉네임</label>
+            <input
+              type="text"
+              name="name"
+              className={styles.input}
+              value={formData.name}
+              onChange={handleChange}
+              placeholder="닉네임을 입력하세요"
+            />
+          </div>
+          <div className={styles.inputGroup}>
+            <label className={styles.label}>전화번호</label>
+            <input
+              type="tel"
+              name="phone"
+              className={styles.input}
+              value={formData.phone}
+              onChange={handleChange}
+              placeholder="010-1234-5678"
+            />
+          </div>
+          <div className={styles.actions}>
+            <button 
+              className={styles.cancelButton} 
+              onClick={handleCancel}
+              disabled={isLoading}
+            >
+              취소
+            </button>
+            <button 
+              className={styles.saveButton} 
+              onClick={handleSave}
+              disabled={isLoading}
+            >
+              {isLoading ? '저장 중...' : '저장'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className={styles.info}>
+            <p className={styles.name}>{user.name}</p>
+            <p className={styles.email}>{user.email}</p>
+            {user.phone && <p className={styles.phone}>{user.phone}</p>}
+          </div>
+          <button className={styles.editButton} onClick={handleEditClick}>
+            수정
+          </button>
+        </>
+      )}
+    </section>
+  )
+}
+
+export default ProfileSection

--- a/src/features/settings/components/ProfileSection.module.scss
+++ b/src/features/settings/components/ProfileSection.module.scss
@@ -1,0 +1,154 @@
+.profileSection {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  position: relative; /* 버튼 배치를 위해 */
+}
+
+.avatar,
+.avatarPlaceholder {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  font-weight: 600;
+  background: #2563eb;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.avatarPlaceholder {
+  background: #cbd5f5;
+  color: #475569;
+}
+
+.info {
+  flex: 1;
+}
+
+.name {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.email {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: #475569;
+}
+
+.phone {
+  margin: 2px 0 0;
+  font-size: 13px;
+  color: #64748b;
+}
+
+/* Edit Form Styles */
+.editForm {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.inputGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.label {
+  font-size: 12px;
+  color: #64748b;
+  font-weight: 500;
+  color: #2563eb;
+}
+
+.input {
+  padding: 8px 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 14px;
+  width: 100%;
+  box-sizing: border-box;
+  background-color: #f8fafc;
+  transition: all 0.2s;
+
+  &:focus {
+    background-color: #fff;
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1);
+  }
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-left: auto; /* 오른쪽 정렬 */
+  margin-top: 4px;
+}
+
+.editButton {
+  padding: 6px 12px;
+  background: #f1f5f9;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #475569;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: #e2e8f0;
+    color: #0f172a;
+  }
+}
+
+.saveButton {
+  padding: 6px 12px;
+  background: #2563eb;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: #1d4ed8;
+  }
+  
+  &:disabled {
+    background: #94a3b8;
+    cursor: not-allowed;
+  }
+}
+
+.cancelButton {
+  padding: 6px 12px;
+  background: transparent;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #64748b;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: #f8fafc;
+    color: #0f172a;
+  }
+}

--- a/src/features/settings/pages/Profile/ProfileEdit.jsx
+++ b/src/features/settings/pages/Profile/ProfileEdit.jsx
@@ -1,8 +1,87 @@
+import { useState, useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
 import MainLayout from '@shared/components/layout/MainLayout'
 import { PROFILE_EDIT_FIELDS } from '@/constants/uiConstants'
-import { Box, Button, Container, Paper, Stack, TextField, Typography } from '@mui/material'
+import { useAuth } from '@features/auth/hooks/useAuth'
+import { Box, Button, Container, Paper, Stack, TextField, Typography, Avatar, IconButton } from '@mui/material'
+import { toast } from '@shared/components/toast/toastStore'
+import EditIcon from '@mui/icons-material/Edit'
 
 export const ProfileEditPage = () => {
+  const navigate = useNavigate()
+  const fileInputRef = useRef(null)
+  const { user, updateUser } = useAuth((state) => ({ 
+    user: state.user, 
+    updateUser: state.updateUser 
+  }))
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    phone: '',
+  })
+  const [previewImage, setPreviewImage] = useState(null)
+  const [selectedFile, setSelectedFile] = useState(null)
+
+  useEffect(() => {
+    if (user) {
+      setFormData({
+        name: user.name || '',
+        email: user.email || '',
+        phone: user.phone || '',
+      })
+      setPreviewImage(user.profileImage)
+    }
+  }, [user])
+
+  const handleChange = (e) => {
+    const { id, value } = e.target
+    setFormData((prev) => ({ ...prev, [id]: value }))
+  }
+
+  const handleFileChange = (e) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      setSelectedFile(file)
+      // 미리보기 URL 생성
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        setPreviewImage(reader.result)
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  const handleAvatarClick = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (isLoading) return
+
+    try {
+      setIsLoading(true)
+      
+      const payload = {
+        name: formData.name,
+        phone: formData.phone?.trim() || null,
+        profileImageFile: selectedFile, // 파일 객체 전달
+      }
+      
+      await updateUser(payload)
+      toast.success('프로필이 업데이트되었습니다.')
+      navigate(-1) // 뒤로 가기
+    } catch (error) {
+      console.error('Profile update failed:', error)
+      const serverMessage = error.response?.data?.message || '프로필 업데이트에 실패했습니다.'
+      toast.error(serverMessage)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   return (
     <MainLayout>
       <Container maxWidth="md" sx={{ py: 3, pb: 10 }}>
@@ -15,7 +94,47 @@ export const ProfileEditPage = () => {
           </Typography>
         </Box>
 
-        <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }} component="form">
+        <Paper 
+          variant="outlined" 
+          sx={{ p: 3, borderRadius: 2 }} 
+          component="form"
+          onSubmit={handleSubmit}
+        >
+          <Box sx={{ display: 'flex', justifyContent: 'center', mb: 3, position: 'relative' }}>
+             <Box sx={{ position: 'relative' }}>
+               <Avatar 
+                 src={previewImage} 
+                 alt={formData.name}
+                 sx={{ width: 100, height: 100, fontSize: '2rem', cursor: 'pointer', border: '2px solid #e2e8f0' }}
+                 onClick={handleAvatarClick}
+               >
+                 {formData.name?.[0] || 'U'}
+               </Avatar>
+               <IconButton
+                 sx={{
+                   position: 'absolute',
+                   bottom: 0,
+                   right: 0,
+                   backgroundColor: 'primary.main',
+                   color: 'white',
+                   width: 32,
+                   height: 32,
+                   '&:hover': { backgroundColor: 'primary.dark' },
+                 }}
+                 onClick={handleAvatarClick}
+               >
+                 <EditIcon sx={{ fontSize: 18 }} />
+               </IconButton>
+             </Box>
+             <input 
+               type="file" 
+               ref={fileInputRef} 
+               hidden 
+               accept="image/*"
+               onChange={handleFileChange}
+             />
+          </Box>
+
           <Stack spacing={2}>
             {PROFILE_EDIT_FIELDS.map((field) => (
               <TextField
@@ -24,17 +143,31 @@ export const ProfileEditPage = () => {
                 label={field.label}
                 type={field.type}
                 placeholder={field.placeholder}
+                value={formData[field.id] || ''}
+                onChange={handleChange}
                 InputProps={{ readOnly: field.readOnly }}
+                disabled={field.readOnly}
                 fullWidth
+                required={field.id === 'name'}
               />
             ))}
 
             <Stack direction="row" spacing={1.5} justifyContent="flex-end" sx={{ pt: 1 }}>
-              <Button type="button" variant="outlined" color="inherit">
+              <Button 
+                type="button" 
+                variant="outlined" 
+                color="inherit"
+                onClick={() => navigate(-1)}
+                disabled={isLoading}
+              >
                 취소
               </Button>
-              <Button type="submit" variant="contained">
-                저장
+              <Button 
+                type="submit" 
+                variant="contained"
+                disabled={isLoading}
+              >
+                {isLoading ? '저장 중...' : '저장'}
               </Button>
             </Stack>
           </Stack>

--- a/src/shared/components/layout/Header.jsx
+++ b/src/shared/components/layout/Header.jsx
@@ -149,13 +149,13 @@ export const Header = ({ navItems = [] }) => {
             direction="row"
             alignItems="center"
             spacing={1}
-            onClick={() => navigate(ROUTE_PATHS.settingsProfile)}
+            onClick={() => navigate(ROUTE_PATHS.settings)}
             role="button"
             tabIndex={0}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault()
-                navigate(ROUTE_PATHS.settingsProfile)
+                navigate(ROUTE_PATHS.settings)
               }
             }}
             sx={{ cursor: 'pointer' }}


### PR DESCRIPTION
- 프로필 편집 페이지(ProfileEditPage) UI 및 기능 구현
- 닉네임, 전화번호 수정 폼 및 이미지 업로드 UI 추가
- 프로필 이미지 클릭 시 파일 선택 및 미리보기 기능 적용
- 사용자 정보 수정 로직 추가
- userApiClient에 프로필 이미지 업로드 API 연동
- authStore에 이미지 업로드 후 정보 수정하는 순차 로직 구현 9 - 헤더 프로필 클릭 시 설정 페이지로 이동하도록 경로 수정

## ✨ PR 요약
<!-- PR의 목적을 간략히 설명해주세요 -->


## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
Closes #
Related to #


## 🛠️ 변경 내용
<!-- 변경 사항을 구체적으로 설명해주세요 -->


## ✅ 체크리스트
<!-- PR 제출 시 확인해주세요! -->
- [ ] 코드가 스타일 가이드라인을 따릅니다.
- [ ] 자체 코드 리뷰를 완료했습니다.
- [ ] 주석을 추가했습니다 (특히 복잡한 로직).
- [ ] 관련 이슈를 링크했습니다.
- [ ] 커밋 메시지가 명확합니다.


## 🙋 리뷰어에게
<!-- 리뷰어가 특별히 확인해주길 원하는 부분이나 고민했던 점을 작성해주세요 -->