### PR TITLE
feat(auth): 회원 탈퇴 및 계정 복구 UI/UX 구현

### DIFF
--- a/src/core/services/api/authApiClient.js
+++ b/src/core/services/api/authApiClient.js
@@ -95,7 +95,12 @@ class AuthApiClient extends ApiClient {
 
     return this.post('/deeplink/resolve', payload, undefined, { mockResponse })
   }
+
+  reactivate(token) {
+    return this.post('/users/reactivate', { token })
+  }
 }
+
 
 export const authApiClient = new AuthApiClient()
 export { AuthApiClient }

--- a/src/features/auth/store/authStore.js
+++ b/src/features/auth/store/authStore.js
@@ -170,6 +170,12 @@ export const useAuthStore = create(
           get().setAuthData(response)
         }),
 
+      reactivate: async (token) =>
+        withLoading(set, async () => {
+          const response = await authApiClient.reactivate(token)
+          get().setAuthData(response)
+        }),
+
       selectRole: async (selectedRole) =>
         withLoading(set, async () => {
           const token = get().token
@@ -231,6 +237,17 @@ export const useAuthStore = create(
         // clearAuthState가 initialState(loading: false 포함)로 완전 리셋
         get().clearAuthState()
       },
+
+      withdraw: async () =>
+        withLoading(set, async () => {
+          try {
+            await userApiClient.deleteMe()
+            get().clearAuthState()
+          } catch (error) {
+            logger.error('회원 탈퇴 실패:', error)
+            throw error
+          }
+        }),
     }),
     {
       name: 'amapill-auth-storage-v2',

--- a/src/features/settings/components/ProfileSection.jsx
+++ b/src/features/settings/components/ProfileSection.jsx
@@ -3,7 +3,10 @@ import { useAuth } from '@features/auth/hooks/useAuth'
 import styles from './ProfileSection.module.scss'
 
 export const ProfileSection = ({ user }) => {
-  const { updateUser } = useAuth((state) => ({ updateUser: state.updateUser }))
+  const { updateUser, withdraw } = useAuth((state) => ({ 
+    updateUser: state.updateUser,
+    withdraw: state.withdraw 
+  }))
   const [isEditing, setIsEditing] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [formData, setFormData] = useState({
@@ -18,6 +21,18 @@ export const ProfileSection = ({ user }) => {
       phone: user?.phone || '',
     })
     setIsEditing(true)
+  }
+
+  const handleWithdraw = async () => {
+    if (window.confirm('정말 탈퇴하시겠습니까?\n탈퇴 시 계정은 비활성화되며, 14일 후 영구 삭제됩니다.')) {
+      try {
+        await withdraw()
+        alert('회원 탈퇴가 완료되었습니다.')
+      } catch (error) {
+        console.error(error)
+        alert('회원 탈퇴 처리에 실패했습니다.')
+      }
+    }
   }
 
   const handleCancel = () => {
@@ -122,6 +137,22 @@ export const ProfileSection = ({ user }) => {
           </div>
           <button className={styles.editButton} onClick={handleEditClick}>
             수정
+          </button>
+          <button 
+            onClick={handleWithdraw}
+            style={{ 
+              display: 'block', 
+              marginTop: '12px', 
+              color: '#ff4444', 
+              fontSize: '0.9rem', 
+              background: 'none', 
+              border: 'none', 
+              textDecoration: 'underline', 
+              cursor: 'pointer',
+              width: '100%'
+            }}
+          >
+            회원탈퇴
           </button>
         </>
       )}

--- a/src/features/settings/pages/Profile/ProfileEdit.jsx
+++ b/src/features/settings/pages/Profile/ProfileEdit.jsx
@@ -10,9 +10,10 @@ import EditIcon from '@mui/icons-material/Edit'
 export const ProfileEditPage = () => {
   const navigate = useNavigate()
   const fileInputRef = useRef(null)
-  const { user, updateUser } = useAuth((state) => ({ 
+  const { user, updateUser, withdraw } = useAuth((state) => ({ 
     user: state.user, 
-    updateUser: state.updateUser 
+    updateUser: state.updateUser,
+    withdraw: state.withdraw 
   }))
 
   const [isLoading, setIsLoading] = useState(false)
@@ -55,6 +56,19 @@ export const ProfileEditPage = () => {
 
   const handleAvatarClick = () => {
     fileInputRef.current?.click()
+  }
+
+  const handleWithdraw = async () => {
+    if (window.confirm('정말 탈퇴하시겠습니까?\n탈퇴 시 계정은 비활성화되며, 14일 후 영구 삭제됩니다.')) {
+      try {
+        await withdraw()
+        toast.success('회원 탈퇴가 완료되었습니다.')
+        navigate('/') // 로그인 페이지 등으로 이동
+      } catch (error) {
+        console.error(error)
+        toast.error('회원 탈퇴 처리에 실패했습니다.')
+      }
+    }
   }
 
   const handleSubmit = async (e) => {
@@ -172,6 +186,17 @@ export const ProfileEditPage = () => {
             </Stack>
           </Stack>
         </Paper>
+
+        <Box sx={{ mt: 4, display: 'flex', justifyContent: 'center' }}>
+          <Button
+            color="error"
+            variant="text"
+            onClick={handleWithdraw}
+            sx={{ textDecoration: 'underline' }}
+          >
+            회원탈퇴
+          </Button>
+        </Box>
       </Container>
     </MainLayout>
   )


### PR DESCRIPTION
feat(auth): 회원 탈퇴 및 계정 복구 UI/UX 구현

- 프로필 편집 페이지(`/settings/profile`)에 **'회원탈퇴' 버튼** 추가 및 로직 연동
- 로그인 페이지(`Login.jsx`)에서 탈퇴 계정 로그인 시 **"계정 복구" 팝업** 처리
- `authStore`에 `withdraw` 및 `reactivate` 액션 구현
- `authApiClient`에 계정 복구 (`POST /auth/users/reactivate`) API 연동

## ✨ PR 요약
<!-- PR의 목적을 간략히 설명해주세요 -->


## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
Closes #
Related to #


## 🛠️ 변경 내용
<!-- 변경 사항을 구체적으로 설명해주세요 -->


## ✅ 체크리스트
<!-- PR 제출 시 확인해주세요! -->
- [ ] 코드가 스타일 가이드라인을 따릅니다.
- [ ] 자체 코드 리뷰를 완료했습니다.
- [ ] 주석을 추가했습니다 (특히 복잡한 로직).
- [ ] 관련 이슈를 링크했습니다.
- [ ] 커밋 메시지가 명확합니다.


## 🙋 리뷰어에게
<!-- 리뷰어가 특별히 확인해주길 원하는 부분이나 고민했던 점을 작성해주세요 -->