### PR TITLE
✨ Feat: Migrate to Adherence API V2 and refactor PDF generation

### DIFF
--- a/src/core/services/api/authApiClient.js
+++ b/src/core/services/api/authApiClient.js
@@ -67,6 +67,9 @@ class AuthApiClient extends ApiClient {
   }
 
   logout(token) {
+    if (!token) {
+      return Promise.resolve({ success: true })
+    }
     const config = {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/core/services/api/medicationLogApiClient.js
+++ b/src/core/services/api/medicationLogApiClient.js
@@ -75,12 +75,24 @@ class MedicationLogApiClient extends ApiClient {
   }
 
   /**
-   * 복약 순응도 요약 조회
-   * @param {number} days - 최근 며칠 (기본: 30)
+   * 복약 순응도 요약 조회 (v2)
    * @returns {Promise<Object>} 순응도 요약 데이터
+   * @returns {Object} response.all - 전체 기간 통계 { rate, scheduled, completed }
+   * @returns {Object} response.last7Days - 최근 7일 통계 { rate, scheduled, completed }
+   * @returns {Object} response.last30Days - 최근 30일 통계 { rate, scheduled, completed }
+   * @returns {Object} response.last365Days - 최근 365일 통계 { rate, scheduled, completed }
+   * @returns {number} response.streak - 연속 복용 일수
    */
-  getAdherenceSummary(days = 30) {
-    return this.get('/adherence/summary', { params: { days } })
+  getAdherenceSummary() {
+    return this.get('/adherence/summary')
+  }
+
+  /**
+   * 복약 순응도 리포트 PDF 다운로드
+   * @returns {Promise<Blob>} PDF 파일 Blob
+   */
+  getAdherenceSummaryPdf() {
+    return this.get('/adherence/summary/pdf', { responseType: 'blob' })
   }
 
   /**


### PR DESCRIPTION
# PR-125: Frontend Adherence API v2 Migration + PDF Download

## ✨ PR 요약
백엔드 복약 순응도(Adherence) API가 v2 응답 구조로 변경됨에 따라, 리포트 화면과 API 클라이언트를 **v2 스펙에 맞게 수정**하고,
PDF 생성은 프론트 `window.print()`가 아닌 **백엔드 PDF 다운로드 API**를 호출하도록 전환했습니다.

## 🔗 관련 이슈
- Close: #125 

## 🛠️ 변경 내용
- **API Client 업데이트**: `getAdherenceSummary(days)` → `getAdherenceSummary()` (v2로 파라미터 제거)
  - `Front/src/core/services/api/medicationLogApiClient.js`
- **리포트 화면 데이터 매핑 변경**:
  - 기존: `overall/thisWeek/thisMonth` 등
  - 변경: `last7Days/last30Days/last365Days/all` + `streak`
  - `Front/src/features/report/pages/AdherenceReportPage.jsx`
- **UI 라벨 변경**:
  - “이번 주/이번 달” → “최근 7일/최근 30일”
- **PDF 다운로드 방식 전환**:
  - 프론트에서 `GET /adherence/summary/pdf` 호출 후 Blob 다운로드

## ✅ 테스트/검증
### 1) 프론트 빌드
- `cd Front && npm run build`

### 2) 수동 브라우저 검증
- 리포트 페이지 진입 시 아래 항목이 정상 렌더링되는지 확인:
  - 최근 7일/30일 퍼센트 표시
  - 연속 복용(streak) 표시
  - 인사이트 문구(최근 7일 vs 30일 비교 포함)
- `PDF 저장` 클릭 시 PDF 파일이 다운로드되는지 확인

### 3) API 계약 확인(백엔드)
- `GET /api/medications/logs/adherence/summary` 응답에 다음 키가 존재해야 함:
  - `all,last7Days,last30Days,last365Days.{rate,scheduled,completed}`, `streak`
- `GET /api/medications/logs/adherence/summary/pdf`는 `application/pdf`로 응답해야 함

## ⚠️ Breaking Change
- 프론트는 v2 응답 구조를 전제로 하므로, **백엔드 v2 배포와 함께 릴리즈**되어야 합니다.

## 🔄 롤백 플랜
- 프론트는 v1 필드(`overall/thisWeek/thisMonth`) 기반 코드를 복구하고,
  PDF 다운로드는 기존 방식(또는 임시 비활성화)으로 되돌리면 롤백 가능합니다.

## ✅ 체크리스트
- [ ] `cd Front && npm run lint`
- [ ] `cd Front && npm run build`
- [ ] 리포트 페이지 수동 확인(PDF 포함)

