### PR TITLE
🐛 Fix: Resolve appointment 500 error (#140)

### DIFF
--- a/src/features/appointment/components/QuickAppointmentModal.jsx
+++ b/src/features/appointment/components/QuickAppointmentModal.jsx
@@ -177,7 +177,7 @@ export const QuickAppointmentModal = ({ open, onClose, placeData, onSuccess }) =
         >
             <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1, pb: 1 }}>
                 <HospitalIcon color="primary" />
-                <Typography variant="h6" sx={{ fontWeight: 700, flex: 1 }}>
+                <Typography variant="h6" component="span" sx={{ fontWeight: 700, flex: 1 }}>
                     빠른 진료 일정 등록
                 </Typography>
                 <IconButton onClick={handleClose} edge="end" size="small">

--- a/src/features/auth/store/authStore.js
+++ b/src/features/auth/store/authStore.js
@@ -138,7 +138,10 @@ export const useAuthStore = create(
           window.localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN)
           window.localStorage.removeItem(STORAGE_KEYS.USER_DATA)
           window.localStorage.removeItem(STORAGE_KEYS.ROLE)
+          window.localStorage.removeItem(STORAGE_KEYS.KAKAO_STATE)
           window.localStorage.removeItem('amapill-auth-storage-v2')
+          // 세션 관련 데이터도 정리 (보호자가 선택한 어르신 정보)
+          window.localStorage.removeItem('amapill-care-target-v1')
         }
 
         // 2. Zustand 상태 초기화 (persist가 빈 상태 저장할 수 있음)
@@ -199,26 +202,26 @@ export const useAuthStore = create(
           if (data.profileImageFile) {
             const imageResponse = await userApiClient.uploadProfileImage(data.profileImageFile)
             // imageResponse가 user 객체를 반환한다고 가정 (백엔드 로직에 따름)
-            updatedUser = imageResponse 
+            updatedUser = imageResponse
           }
 
           // 2. 텍스트 정보 업데이트 (이름, 전화번호 등)
           // 이미지만 바꾼 경우 텍스트 업데이트 생략 가능하지만, 
           // 안전하게 텍스트 정보도 같이 보냄 (또는 data에서 file 제외하고 보냄)
           const { profileImageFile, ...textData } = data
-          
+
           // 텍스트 데이터가 변경된 게 있으면 호출
           if (Object.keys(textData).length > 0) {
-             updatedUser = await userApiClient.updateMe(textData)
+            updatedUser = await userApiClient.updateMe(textData)
           }
 
           // 기존 토큰 등은 유지하고 user 정보만 업데이트
           const currentUser = get().user
           // updatedUser가 없으면(둘 다 실행 안됨?) 기존 유지
           const finalUser = updatedUser || currentUser
-          
+
           const newUserState = { ...currentUser, ...finalUser }
-          
+
           get().setAuthData({
             ...get(), // 기존 토큰 및 상태 유지
             user: newUserState

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,11 +37,11 @@ export default defineConfig(({ command, mode }) => {
       cors: true,         // CORS 허용
       proxy: {
         '/api': {
-          target: 'http://localhost:8080',  // Gateway로 직접 연결
+          target: 'http://localhost:80',  // Nginx → Gateway로 연결
           changeOrigin: true,
         },
         '/ws': {
-          target: 'ws://localhost:8080',    // WebSocket
+          target: 'ws://localhost:80',    // WebSocket via Nginx
           ws: true,
         }
       }


### PR DESCRIPTION
## ✨ PR 요약
병원 예약 생성 시 발생하는 500 Internal Server Error 및 관련 프론트엔드 오류들을 수정했습니다.
(JWT 만료 문제, 로그아웃 시 세션 잔여 데이터, Vite 프록시 설정 오류, DOM 중첩 경고 해결)

## 🔗 관련 이슈
Closes #140

## 🛠️ 변경 내용
1. **Vite 프록시 설정 수정 (`vite.config.js`)**
    - 개발 서버(`npm run dev`)의 API 프록시 타겟을 Gateway 직접 연결(`8080`)에서 Nginx(`80`)로 변경하여 라우팅 불일치 해결.
2. **로그아웃 세션 정리 (`authStore.js`)**
    - 로그아웃 시 `KAKAO_STATE` 및 `care-target` (선택된 어르신 정보)이 `localStorage`에 남지 않도록 삭제 로직 추가.
3. **DOM 중첩 오류 수정 (`QuickAppointmentModal.jsx`)**
    - `DialogTitle` 내부의 `Typography` 컴포넌트가 `h2` 안에 `h6`를 렌더링하여 발생하는 React Hydration 경고 수정 (`component="span"` 적용).

## ✅ 체크리스트
- [x] 코드가 스타일 가이드라인을 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다.
- [x] 관련 이슈를 링크했습니다.
- [x] 커밋 메시지가 명확합니다.

## 🙋 리뷰어에게
- 프록시 설정 변경(`port 80`)으로 인해 로컬 개발 환경에서 Nginx 컨테이너가 실행 중이어야 API 요청이 정상적으로 동작합니다 (`docker-compose up -d` 확인 필요).
- 예약 생성 흐름이 정상적으로 201 응답을 받는지 확인 부탁드립니다.
