### PR TITLE
🐛 Fix: 로그아웃 시 스토어 초기화 (403 에러 해결)

### DIFF
--- a/src/features/dashboard/store/careTargetStore.js
+++ b/src/features/dashboard/store/careTargetStore.js
@@ -10,6 +10,9 @@ export const useCareTargetStore = create(
       activeSeniorMemberId: null,
       setActiveSeniorMemberId: (memberId) => set({ activeSeniorMemberId: memberId != null ? String(memberId) : null }),
       clearActiveSeniorMemberId: () => set({ activeSeniorMemberId: null }),
+
+      // 상태 초기화 (로그아웃 시 호출)
+      reset: () => set({ activeSeniorMemberId: null }),
     }),
     {
       name: STORAGE_KEY,
@@ -19,5 +22,12 @@ export const useCareTargetStore = create(
     },
   ),
 )
+
+// 글로벌 로그아웃 이벤트 리스너 등록
+if (typeof window !== 'undefined') {
+  window.addEventListener('app:auth:logout', () => {
+    useCareTargetStore.getState().reset()
+  })
+}
 
 export default useCareTargetStore

--- a/src/features/diet/components/DietEntryModal.jsx
+++ b/src/features/diet/components/DietEntryModal.jsx
@@ -54,7 +54,7 @@ export const DietEntryModal = ({ open, onClose }) => {
             }}
         >
             <DialogTitle sx={{ m: 0, p: 2, display: 'flex', alignItems: 'center', justifyContent: 'space-between', bgcolor: 'background.paper' }}>
-                <Typography variant="h6" fontWeight="bold">
+                <Typography variant="h6" component="span" fontWeight="bold">
                     식단 기록
                 </Typography>
                 <IconButton

--- a/src/features/family/store/familyStore.js
+++ b/src/features/family/store/familyStore.js
@@ -306,6 +306,17 @@ export const useFamilyStore = create((set, get) => ({
   },
 
   refetchFamily: async () => get().loadFamily(),
+
+  reset: () => {
+    set(initialState)
+  },
 }))
+
+// 글로벌 로그아웃 이벤트 리스너 등록 (Store 외부에서 구독)
+if (typeof window !== 'undefined') {
+  window.addEventListener('app:auth:logout', () => {
+    useFamilyStore.getState().reset()
+  })
+}
 
 export default useFamilyStore


### PR DESCRIPTION
## ✨ PR 요약
사용자 로그아웃 및 계정 전환 시 프론트엔드 스토어(Family, CareTarget)에 남아있는 데이터로 인해 발생하는 403 Forbidden 에러를 해결했습니다.
`authStore`에서 **Event-Driven 아키텍처 (`app:auth:logout`)**를 도입하여, 로그아웃 시 각 스토어가 스스로 상태를 초기화하도록 수정했습니다.

## 🔗 관련 이슈
Closes #160

## 🛠️ 변경 내용
- **`authStore.js`**:
    - 로그아웃(`logout`) 시 `window.dispatchEvent(new Event('app:auth:logout'))` 이벤트 발행.
    - 로그인(`setAuthData`) 시 사용자 변경이 감지되면 안전장치(Safety Net)로 위 이벤트 자동 발행.
    - 다른 스토어에 대한 직접 `import` 제거 (Decoupling).
- **`familyStore.js`**:
    - `reset()` 액션 추가.
    - `app:auth:logout` 이벤트 리스너 등록 → 이벤트 발생 시 `reset()` 호출.
- **`careTargetStore.js`**:
    - `reset()` 액션 추가.
    - `app:auth:logout` 이벤트 리스너 등록 → 이벤트 발생 시 `reset()` 호출.

## ✅ 체크리스트
- [x] 코드가 스타일 가이드라인을 따릅니다.
- [x] 자체 코드 리뷰를 완료했습니다. (Garbage Rule Pass)
- [x] 주석을 추가했습니다 (Event-Driven 로직 설명).
- [x] 관련 이슈를 링크했습니다.
- [x] 커밋 메시지가 명확합니다.

## 🙋 리뷰어에게
`authStore`가 더 이상 다른 스토어를 알 필요가 없도록 의존성을 제거했습니다. 이제 새로운 스토어가 추가되더라도 `authStore` 수정 없이 `app:auth:logout` 이벤트만 구독하면 됩니다.
